### PR TITLE
Update ci_for_prop.qmd

### DIFF
--- a/R/ci_for_prop.qmd
+++ b/R/ci_for_prop.qmd
@@ -88,7 +88,7 @@ Code example for Blaker's exact method:\
 Code example for Clopper-pearson:\
 `binconf(x=<count of successes> , n=<Total>,method="exact",alpha=0.05)`
 
-**The {RBesT} package** produces CIs using the Clopper-Pearson method. In this example (x=36 and n=154), the results match the cardx package. However, as described below, there are 2 cases where the results using RBesT package do not match cardx or Hmisc.
+**The {RBesT} package (Prior to Version 1.8-0)** produces CIs using the Clopper-Pearson method. In this example (x=36 and n=154), the results match the cardx package. However, as described below, there are 2 cases where the results using RBesT package do not match cardx or Hmisc.
 
 1)  x = 0 (0% responders), in which case the lower limit does not match.
 2)  x = n (100% responders), in which case the upper limit does not match.
@@ -101,13 +101,12 @@ RBesT equations are:\
 pLow \<- qbeta(Low, r + (r == 0), n - r + 1)\
 pHigh \<- qbeta(High, r + 1, n - r + ((n - r) == 0))
 
-If the equations were updated as follows then it would match Hmisc intervals:\
+In Version 1.8-0 onwards the equations were updated as follows, which then match the Hmisc intervals:\
 pLow \<- qbeta(Low, r, n - r + 1)\
 pHigh \<- qbeta(High, r + 1, n - r)
 
 `BinaryExactCI(x=<count of successes> , n=<Total>,alpha=0.05)`
 
-It is currently unclear why the RBesT script has the logical conditions (r==0) and ((n-r)==0. Therefore, we currently do not recommend using this package and suggest cardx or Hmisc is used instead. For updates about this, see the [issue](https://github.com/Novartis/RBesT/issues/21)
 
 **The {ExactCIdiff} package** produces CIs for two dependent proportions (matched pairs) and two independent proportions (unmatched pairs).
 


### PR DESCRIPTION
NOvartis/Rbest issue #21: The upcoming 1.8-0 release will fix the issue. You can grab a draft of the release as per below. Many thanks again for reporting. I will close once the new release is on CRAN. # install.packages("remotes") # needed if package remotes is not available # grabs current draft of the upcoming 1.8-0 release remotes::install_github("weberse2/RBesT", ref="issue-prep-1-8-0-release")