### PR TITLE
Marginal Homogeneity Tests

### DIFF
--- a/Comp/r-sas_mcnemar.qmd
+++ b/Comp/r-sas_mcnemar.qmd
@@ -2,33 +2,68 @@
 title: "R v SAS McNemar's test"
 ---
 
-**McNemar's test; R and SAS**
+## Introduction
 
-In R, the `mcNemar` function from the `epibasix` package can be used to perform McNemar's test.
+McNemar's test is a test of marginal homogeneity. That is used with 2x2 contingency tables, when both x and y are binary factors.
 
-```{r, eval=FALSE}
-X<-table(colds$age12,colds$age14)
-summary(mcNemar(X))
+## General Comparison Table
 
+The following table provides an overview of the support and results comparability between R and SAS for the new analysis point.
+
+| Analysis | Supported in R | Supported in SAS | Results Match | Notes |
+|---------------|---------------|---------------|---------------|---------------|
+| McNemar's Chi-Squared test | [Yes](../R/mcnemar.qmd) | [Yes](../SAS/mcnemar.qmd) | ✅ | By default SAS doesn't include the continuity correction. |
+| Cohen's Kappa CI | [Yes](../R/mcnemar.qmd) | [Yes](../SAS/mcnemar.qmd) | ✅ |  |
+
+In R,the {stats} or the {coin} package can be used to calculate McNemar. The {coin} package has the same defaults as SAS. But, using either of these packages, the first step is to calculate a frequency table, using the table function.
+
+```{r}
+library(coin)
+colds <- 
+  read.csv(
+    file = "../data/colds.csv")
+freq_tbl <- table("age12" = colds$age12, "age14" = colds$age14)
+freq_tbl
+coin::mh_test(freq_tbl)
+
+```
+
+In order to get Cohen's Kappa an additional package is needed.
+
+```{r}
+library(vcd)
+cohen_kappa <- Kappa(freq_tbl)
+cohen_kappa
+confint(cohen_kappa, level = 0.95)
 ```
 
 The FREQ procedure can be used in SAS with the AGREE option to run the McNemar test, with OR, and RISKDIFF options stated for production of odds ratios and risk difference. These options were added as `epibasix::mcNemar` outputs the odds ratio and risk difference with confidence limits as default. In contrast to R, SAS outputs the Kappa coefficients with confident limits as default.
 
-```{r, eval=FALSE}
+``` sas
 proc freq data=colds;
-	tables age12*age14 / agree or riskdiff;
+    tables age12*age14 / agree or riskdiff;
 run;
 ```
 
+```{r, echo=FALSE, fig.align='center', out.width="40%"}
+knitr::include_graphics("../images/mcnemar/sas-mcnemar.png")
+```
+
+## Summary and Recommendation
 When calculating the odds ratio and risk difference confidence limits, SAS is not treating the data as matched-pairs. There is advice on the SAS blog and SAS support page to amend this, which requires a lot of additional coding.
 
-R is using Edward's continuity correction with no option to remove this. In contrast, there is no option to include Edward's continuity correction in SAS, but this can be manually coded to agree with R. However, its use is controversial due to being seen as overly conservative.
+{stats} is using Edward's continuity correction by default, but this can be removed. In contrast, there is no option to include Edward's continuity correction in SAS, but this can be manually coded to agree with R. However, its use is controversial due to being seen as overly conservative.
 
-R's use of the continuity correction is consistent with other functions within the `epibasix` package, which was categorised as 'High Risk' by the Risk Assessment Shiny App created by the R Validation Hub. Risk is quantified by the app through a number of metrics relating to maintenance and community usage. It was found that the author is no longer maintaining the package and there was no documentation available for certain methods used. Therefore, the use of the `epibasix` package is advised against and other packages may be more suitable.
+There is another R package that is sometimes used to calculate McNemar's, called `epibasix`. This package is no longer being maintained, and there was no documentation available for certain methods used. Therefore, the use of the `epibasix` package is advised against and other packages may be more suitable.
 
-The `mcnemar.test` function in the `stats` package provides the option to remove continuity corrections which results in a match with SAS. This function does not output any other coefficients for agreement/difference in proportions etc. but (if required) these can be achieved within other functions and/or packages.
-
-```{r, eval=FALSE}
-mcnemar.test(X, correct = FALSE)
-
+::: {.callout-note collapse="true" title="Session Info"}
+```{r}
+#| echo: false
+si <- sessioninfo::session_info(
+  c("coin", "stats"), #Vector of packages used 
+  dependencies = FALSE)
+si$external <- structure(list("SAS" = "9.04.01M7P080520"), class = c("external_info", "list"))
+si
 ```
+:::
+

--- a/R/marginal_homogeneity_tests.qmd
+++ b/R/marginal_homogeneity_tests.qmd
@@ -1,0 +1,222 @@
+---
+title: "Marginal Homogeneity Tests"
+---
+
+This page is solely based on **coin** package documentation including data samples which are generated inline.
+
+`coin::mh_test()` provides the McNemar test, the Cochran Q test, the Stuart(-Maxwell) test and the Madansky test of interchangeability. A general description of these methods is given by Agresti (2002).
+
+The null hypothesis of marginal homogeneity is tested. If formula interface is used, the response variable and the measurement conditions are given by `y` and `x`, respectively, and `block` is a factor where each level corresponds to exactly one subject with repeated measurements: `coin::mh_test(y ~ x | block, data, subset = NULL, ...)`. We can also directly pass an object of class `"table"`.
+
+`coin::mh_test()` computes different tests depending on `x` and `y`:
+
+-   McNemar test (McNemar, 1947) when both `y` and `x` are binary factors;
+
+-   Cochran Q test (Cochran, 1950) when `y` is a binary factor and `x` is a factor with an arbitrary number of levels;
+
+-   Stuart-Maxwell test (Stuart, 1955; Maxwell, 1970) when `y` is a factor with an arbitrary number of levels and `x` is a binary factor;
+
+-   Madansky test of interchangeability (Madansky, 1963), which implies marginal homogeneity, when both `y` and `x` are factors with an arbitrary number of levels.
+
+The conditional null distribution of the test statistic is used to obtain p-values and an asymptotic approximation of the exact distribution is used by default (`distribution = "asymptotic"`). Alternatively, the distribution can be approximated via Monte Carlo resampling or computed exactly for univariate two-sample problems (McNemar test) by setting distribution to `"approximate"` or `"exact"`, respectively.
+
+## McNemar test
+
+McNemar test  is calculated [without continuity correction]{.underline} which corresponds to SAS FREQ procedure (see [R v SAS McNemar’s test](https://psiaims.github.io/CAMIS/Comp/r-sas_mcnemar.html) for more details).
+
+```{r}
+## Performance of prime minister
+## Agresti (2002, p. 409)
+performance <- matrix(
+  c(794, 150,
+    86, 570),
+  nrow = 2, 
+  byrow = TRUE,
+  dimnames = list(
+    "First" = c("Approve", "Disprove"),
+    "Second" = c("Approve", "Disprove")
+  )
+)
+performance <- as.table(performance)
+
+performance
+
+## Asymptotic McNemar Test
+# Corresponds to SAS FREQ procedure
+coin::mh_test(performance)
+
+## Approximative McNemar Test
+coin::mh_test(
+  performance, 
+  distribution = coin::approximate(nresample = 10000)
+)
+
+## Exact McNemar Test
+coin::mh_test(performance, distribution = "exact")
+```
+
+
+## Cochran Q test
+
+```{r}
+## Effectiveness of different media for the growth of diphtheria
+## Cochran (1950, Tab. 2)
+cases <- c(4, 2, 3, 1, 59)
+n <- sum(cases)
+cochran <- data.frame(
+  diphtheria = factor(
+    unlist(rep(list(c(1, 1, 1, 1),
+                    c(1, 1, 0, 1),
+                    c(0, 1, 1, 1),
+                    c(0, 1, 0, 1),
+                    c(0, 0, 0, 0)),
+                cases)
+    )
+  ),
+  media = factor(rep(LETTERS[1:4], n)),
+  case =  factor(rep(seq_len(n), each = 4))
+)
+
+head(cochran)
+
+## Asymptotic Cochran Q test (Cochran, 1950, p. 260)
+coin::mh_test(
+  diphtheria ~ media | case, 
+  data = cochran
+) 
+
+## Approximative Cochran Q test
+mt <- coin::mh_test(
+  diphtheria ~ media | case, 
+  data = cochran,
+  distribution = coin::approximate(nresample = 10000)
+)
+coin::pvalue(mt)             # standard p-value
+coin::midpvalue(mt)          # mid-p-value
+coin::pvalue_interval(mt)    # p-value interval
+coin::size(mt, alpha = 0.05) # test size at alpha = 0.05 using the p-value
+```
+
+
+## Stuart-Maxwell test
+
+```{r}
+## Opinions on Pre- and Extramarital Sex
+## Agresti (2002, p. 421)
+opinions <- c("Always wrong", "Almost always wrong",
+              "Wrong only sometimes", "Not wrong at all")
+PreExSex <- matrix(
+  c(144, 33, 84, 126,
+    2,  4, 14,  29,
+    0,  2,  6,  25,
+    0,  0,  1,   5),
+  nrow = 4,
+  dimnames = list(
+    "Premarital Sex" = opinions,
+    "Extramarital Sex" = opinions
+  )
+)
+PreExSex <- as.table(PreExSex)
+
+PreExSex
+
+## Asymptotic Stuart test
+coin::mh_test(PreExSex)
+
+## Asymptotic Stuart-Birch test
+## Note: response as ordinal
+coin::mh_test(
+  PreExSex, 
+  scores = list(response = 1:length(opinions))
+)
+```
+
+
+## Madansky test of interchangeability
+
+```{r}
+## Vote intention
+## Madansky (1963, pp. 107-108)
+vote <- array(
+    c(120, 1,  8, 2,   2,  1, 2, 1,  7,
+        6, 2,  1, 1, 103,  5, 1, 4,  8,
+       20, 3, 31, 1,   6, 30, 2, 1, 81),
+    dim = c(3, 3, 3),
+    dimnames = list(
+          "July" = c("Republican", "Democratic", "Uncertain"),
+        "August" = c("Republican", "Democratic", "Uncertain"),
+          "June" = c("Republican", "Democratic", "Uncertain")
+    )
+)
+vote <- as.table(vote)
+
+vote
+
+## Asymptotic Madansky test (Q = 70.77)
+coin::mh_test(vote)
+
+## Cross-over study
+## http://www.nesug.org/proceedings/nesug00/st/st9005.pdf (link is dead now)
+dysmenorrhea <- array(
+  c(6, 2, 1,  3, 1, 0,  1, 2, 1,
+    4, 3, 0, 13, 3, 0,  8, 1, 1,
+    5, 2, 2, 10, 1, 0, 14, 2, 0),
+  dim = c(3, 3, 3),
+  dimnames =  list(
+    "Placebo" = c("None", "Moderate", "Complete"),
+    "Low dose" = c("None", "Moderate", "Complete"),
+    "High dose" = c("None", "Moderate", "Complete")
+  )
+)
+dysmenorrhea <- as.table(dysmenorrhea)
+
+dysmenorrhea
+
+## Asymptotic Madansky-Birch test (Q = 53.76)
+## Note: response as ordinal
+coin::mh_test(
+  dysmenorrhea, 
+  scores = list(response = 1:3)
+)
+
+## Asymptotic Madansky-Birch test (Q = 47.29)
+## Note: response and measurement conditions as ordinal
+coin::mh_test(
+  dysmenorrhea, 
+  scores = list(response = 1:3, conditions = 1:3)
+)
+```
+
+
+## Reference
+
+Hothorn T, Hornik K, van de Wiel MA, Zeileis A (2006). A Lego system for conditional inference. The American Statistician, 60 (3), 257-263. doi:10.1198/000313006X118430 <https://doi.org/10.1198/000313006X118430>
+
+Agresti, A. (2002). Categorical Data Analysis, Second Edition. Hoboken, New Jersey: John Wiley & Sons.
+
+Birch, M. W. (1965). The detection of partial association, II: The general case. Journal of the Royal Statistical Society B 27(1), 111–124. doi:10.1111/j.2517-6161.1965.tb00593.x
+
+Cochran, W. G. (1950). The comparison of percentages in matched samples. Biometrika 37(3/4), 256–266. doi:10.1093/biomet/37.3-4.256
+
+Madansky, A. (1963). Tests of homogeneity for correlated samples. Journal of the American Statistical Association 58(301), 97–119. doi:10.1080/01621459.1963.10500835
+
+Maxwell, A. E. (1970). Comparing the classification of subjects by two independent judges. British Journal of Psychiatry 116(535), 651–655. doi:10.1192/bjp.116.535.651
+
+McNemar, Q. (1947). Note on the sampling error of the difference between correlated proportions or percentages. Psychometrika 12(2), 153–157. doi:10.1007/BF02295996
+
+Stuart, A. (1955). A test for homogeneity of the marginal distributions in a two-way classification. Biometrika 42(3/4), 412–416. doi:10.1093/biomet/42.3-4.412
+
+White, A. A., Landis, J. R. and Cooper, M. M. (1982). A note on the equivalence of several marginal homogeneity test criteria for categorical data. International Statistical Review 50(1), 27–34. doi:10.2307/1402457
+
+
+::: {.callout-note collapse="true" title="Session Info"}
+```{r}
+#| echo: false
+
+# List all the packages needed 
+si <- sessioninfo::session_info(c(
+  #Create a vector of all the packages used in this file 
+))
+si
+```
+:::

--- a/R/marginal_homogeneity_tests.qmd
+++ b/R/marginal_homogeneity_tests.qmd
@@ -22,38 +22,8 @@ The conditional null distribution of the test statistic is used to obtain p-valu
 
 ## McNemar test
 
-McNemar test is calculated [without continuity correction]{.underline} which corresponds to SAS FREQ procedure (see [R v SAS McNemar’s test](https://psiaims.github.io/CAMIS/Comp/r-sas_mcnemar.html) for more details).
+For more information on the McNemar see the [McNemar’s test](https://psiaims.github.io/CAMIS/Comp/r_mcnemar.html) page.
 
-```{r}
-## Performance of prime minister
-## Agresti (2002, p. 409)
-performance <- matrix(
-  c(794, 150,
-    86, 570),
-  nrow = 2, 
-  byrow = TRUE,
-  dimnames = list(
-    "First" = c("Approve", "Disprove"),
-    "Second" = c("Approve", "Disprove")
-  )
-)
-performance <- as.table(performance)
-
-performance
-
-## Asymptotic McNemar Test
-# Corresponds to SAS FREQ procedure
-coin::mh_test(performance)
-
-## Approximative McNemar Test
-coin::mh_test(
-  performance, 
-  distribution = coin::approximate(nresample = 10000)
-)
-
-## Exact McNemar Test
-coin::mh_test(performance, distribution = "exact")
-```
 
 ## Cochran Q test
 

--- a/R/marginal_homogeneity_tests.qmd
+++ b/R/marginal_homogeneity_tests.qmd
@@ -22,7 +22,7 @@ The conditional null distribution of the test statistic is used to obtain p-valu
 
 ## McNemar test
 
-For more information on the McNemar see the [McNemar’s test](https://psiaims.github.io/CAMIS/Comp/r_mcnemar.html) page.
+For more information on the McNemar see the [McNemar’s test](https://psiaims.github.io/CAMIS/R/r_mcnemar.html) page.
 
 
 ## Cochran Q test

--- a/R/marginal_homogeneity_tests.qmd
+++ b/R/marginal_homogeneity_tests.qmd
@@ -22,7 +22,7 @@ The conditional null distribution of the test statistic is used to obtain p-valu
 
 ## McNemar test
 
-McNemar test  is calculated [without continuity correction]{.underline} which corresponds to SAS FREQ procedure (see [R v SAS McNemar’s test](https://psiaims.github.io/CAMIS/Comp/r-sas_mcnemar.html) for more details).
+McNemar test is calculated [without continuity correction]{.underline} which corresponds to SAS FREQ procedure (see [R v SAS McNemar’s test](https://psiaims.github.io/CAMIS/Comp/r-sas_mcnemar.html) for more details).
 
 ```{r}
 ## Performance of prime minister
@@ -54,7 +54,6 @@ coin::mh_test(
 ## Exact McNemar Test
 coin::mh_test(performance, distribution = "exact")
 ```
-
 
 ## Cochran Q test
 
@@ -97,7 +96,6 @@ coin::pvalue_interval(mt)    # p-value interval
 coin::size(mt, alpha = 0.05) # test size at alpha = 0.05 using the p-value
 ```
 
-
 ## Stuart-Maxwell test
 
 ```{r}
@@ -130,7 +128,6 @@ coin::mh_test(
   scores = list(response = 1:length(opinions))
 )
 ```
-
 
 ## Madansky test of interchangeability
 
@@ -187,7 +184,6 @@ coin::mh_test(
 )
 ```
 
-
 ## Reference
 
 Hothorn T, Hornik K, van de Wiel MA, Zeileis A (2006). A Lego system for conditional inference. The American Statistician, 60 (3), 257-263. doi:10.1198/000313006X118430 <https://doi.org/10.1198/000313006X118430>
@@ -208,14 +204,13 @@ Stuart, A. (1955). A test for homogeneity of the marginal distributions in a two
 
 White, A. A., Landis, J. R. and Cooper, M. M. (1982). A note on the equivalence of several marginal homogeneity test criteria for categorical data. International Statistical Review 50(1), 27–34. doi:10.2307/1402457
 
-
 ::: {.callout-note collapse="true" title="Session Info"}
 ```{r}
 #| echo: false
 
 # List all the packages needed 
 si <- sessioninfo::session_info(c(
-  #Create a vector of all the packages used in this file 
+  "coin"
 ))
 si
 ```

--- a/R/mcnemar.qmd
+++ b/R/mcnemar.qmd
@@ -11,9 +11,6 @@ To demonstrate McNemar's test, data was used concerning the presence or absence 
 ```{r}
 #| echo: false
 #| include: false
-library(knitr)
-
-knitr::opts_chunk$set(echo = TRUE, cache = TRUE)
 
 colds <- 
   read.csv(
@@ -33,7 +30,6 @@ The other possible input to `mcnemar.test` is `correct =` which is a true/false 
 
 ```{r}
 mcnemar.test(freq_tbl, correct=FALSE)
-
 ```
 ## Example Code using {coin}
 

--- a/R/mcnemar.qmd
+++ b/R/mcnemar.qmd
@@ -4,7 +4,9 @@ title: "McNemar's test in R"
 
 ### Performing McNemar's test in R
 
-To demonstrate McNemar's test, data was used concerning the presence or absence of cold symptoms reported by the same children at age 12 and age 14. A total of 2638 participants were involved.
+The McNemar test is a statistical test used to determine if there are significant differences in the paired proportions of categorical data. It is particularly useful for testing the change in responses before and after an intervention on the same subjects, such as in pre-test/post-test study designs. By comparing the discordant pairs, where outcomes change in one direction versus the opposite, the McNemar test assesses if the intervention or treatment has a statistically significant effect on the outcome.
+
+To demonstrate McNemar's test, data was used concerning the presence or absence of cold symptoms reported by the same children at age 12 and age 14. A total of 2638 participants were involved, with the interest being in whether the prevalence was significantly different at either age. In order to use any of the packages to calculate first we need to convert our data into a frequency table.  
 
 ```{r}
 #| echo: false
@@ -16,37 +18,70 @@ knitr::opts_chunk$set(echo = TRUE, cache = TRUE)
 colds <- 
   read.csv(
     file = "../data/colds.csv")
+freq_tbl <- table("age12" = colds$age12, "age14" = colds$age14)
+freq_tbl
 ```
 
-#### Using the `epibasix::mcnemar` function
-
-Testing for a significant difference in cold symptoms between the two ages using the `mcNemar` function from the `epibasix` package can be performed as below. The symptoms for participants at age 12 and age 14 are tabulated and stored as an object, then passed to the `mcNemar` function. A more complete view of the output is achieved by calling the `summary` function.
-
-```{r}
-library(epibasix)
-
-X <- table(colds$age12, colds$age14)
-epi_mcn <- mcNemar(X)
-summary(epi_mcn)
-```
-
-#### Using the `stats::mcnemar.test` function
+## Example Code using {stats}
 
 McNemar's test can also be performed using `stats::mcnemar.test` as shown below, using the same table `X` as in the previous section.
 
 ```{r}
-mcnemar.test(X)
+mcnemar.test(freq_tbl)
 ```
-
-The result is shown without continuity correction by specifying `correct=FALSE`.
+The other possible input to `mcnemar.test` is `correct =` which is a true/false value to indicate if the continuity correction should be applied. To get the result without continuity correction by specify `correct=FALSE`.
 
 ```{r}
-mcnemar.test(X, correct=FALSE)
+mcnemar.test(freq_tbl, correct=FALSE)
 
 ```
+## Example Code using {coin}
+
+McNemar test is calculated [without continuity correction]{.underline} which corresponds to SAS FREQ procedure (see [R v SAS McNemar’s test](https://psiaims.github.io/CAMIS/Comp/r-sas_mcnemar.html) for more details).
+```{r}
+library(coin)
+## Asymptotic McNemar Test
+# Corresponds to SAS FREQ procedure
+coin::mh_test(freq_tbl)
+
+## Approximative McNemar Test
+coin::mh_test(
+  freq_tbl, 
+  distribution = coin::approximate(nresample = 10000)
+)
+
+## Exact McNemar Test
+coin::mh_test(freq_tbl, distribution = "exact")
+
+```
+#### Calculating Confidence Intervals with {vcd}
+It is common when calculating McNemar, to also want to check the level agreement between the two rates. To do this we use Cohen's Kappa and its associated confidence intervals. To do this, we use the `vcd` package as follows: 
+
+```{r}
+library(vcd)
+cohen_kappa <- Kappa(freq_tbl)
+cohen_kappa
+confint(cohen_kappa, level = 0.95)
+
+
+```
+
+
+
+#### Using the `epibasix::mcnemar` function
+
+Another package that is sometimes used to calculate McNemar is {epibasix}. *This package isn't recommended by CAMIS*. It was found that the author is no longer maintaining the package and there was no documentation available for certain methods used. Therefore, the use of the {epibasix} package is advised against and other packages may be more suitable. 
 
 #### Results
 
-As default, using `summary` with `epibasix::mcNemar` gives additional information to the McNemar's chi-square statistic. This includes a table to view proportions, and odds ratio and risk difference with 95% confidence limits. The result uses Edward's continuity correction without the option to remove this, which is consistent with other functions within the package.
+`stats::mcnemar.test` and `coin::mh_test` are both sutiable options for calculating McNemar. The {coin} package also has a variety of other marginal homogeneity test, for more information [see here](https://psiaims.github.io/CAMIS/R/marginal_homogeneity_tests.html). `stats::mcnemar.test` uses a continuity correction as default but does allow for this to be removed. This function does not output any other coefficients for agreement or proportions but (if required) these can be achieved within other functions or packages in R.
 
-`stats::mcnemar.test` uses a continuity correction as default but does allow for this to be removed. This function does not output any other coefficients for agreement or proportions but (if required) these can be achieved within other functions or packages in R.
+## Reference
+
+Agresti, A. (2002). Categorical Data Analysis, Second Edition. Hoboken, New Jersey: John Wiley & Sons.
+
+Cohen, J. (1960), A coefficient of agreement for nominal scales. Educational and Psychological Measurement, 20, 37–46.
+
+Everitt, B.S. (1968), Moments of statistics kappa and weighted kappa. The British Journal of Mathematical and Statistical Psychology, 21, 97–103.
+
+Fleiss, J.L., Cohen, J., and Everitt, B.S. (1969), Large sample standard errors of kappa and weighted kappa. Psychological Bulletin, 72, 332–327.

--- a/camis.Rproj
+++ b/camis.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 89f64699-ab42-4984-a3b3-e8be471437cf
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/data/stat_method_tbl.csv
+++ b/data/stat_method_tbl.csv
@@ -22,6 +22,7 @@ Non-parametric Analysis,Jonckheere test,[R](R/jonckheere),[SAS](SAS/jonchkheere_
 Non-parametric Analysis,Hodges-Lehman Estimator,[R](R/nparestimate),[SAS](SAS/nparestimate),,
 Categorical Data Analysis,Binomial test,[R](R/binomial_test),,,
 Categorical Data Analysis,McNemar's test,[R](R/mcnemar),[SAS](SAS/mcnemar),,[R vs SAS](Comp/r-sas_mcnemar)
+Categorical Data Analysis,Marginal Homogeneity Tests,[R](R/marginal_homogeneity_tests),,,
 Categorical Data Analysis,Chi-Square Association/Fishers exact,[R](R/association),[SAS](SAS/association),[Python](python/chi-square),[R vs SAS](Comp/r-sas_chi-sq)
 Categorical Data Analysis,Cochran Mantel Haenszel,[R](R/cmh),[SAS](SAS/cmh),,[R vs SAS](Comp/r-sas_cmh)
 Categorical Data Analysis,Confidence Intervals for proportions,[R](R/ci_for_prop),[SAS](SAS/ci_for_prop),,[R vs SAS](Comp/r-sas_ci_for_prop)

--- a/renv.lock
+++ b/renv.lock
@@ -1345,16 +1345,6 @@
       ],
       "Hash": "68cb418754ae04b2bcb4377dda09ce2b"
     },
-    "epibasix": {
-      "Package": "epibasix",
-      "Version": "1.5",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
-      "Hash": "73da74228bdf4e762519188d68d1258d"
-    },
     "estimability": {
       "Package": "estimability",
       "Version": "1.5.1",


### PR DESCRIPTION
`coin::mh_test()` is the most generic solution for marginal homogeneity tests including McNemar test.
`epibasix::mcnemar()` in https://psiaims.github.io/CAMIS/R/mcnemar.html is also valuable as it computes Odds Ratio with CI (but it doesn't reproduce default SAS behavior).
`stats::mcnemar.test()` in https://psiaims.github.io/CAMIS/Comp/r-sas_mcnemar.html can be replaced with `coin::mh_test()` .
This manual is just retelling of `?mh_test` help page, for more detailed comparison some SAS references are needed.