### PR TITLE
Add PR Previews

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -53,4 +53,6 @@ jobs:
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: _site # The folder the action should deploy.
-    
+          # Don't remove preview deployments
+          clean-exclude: pr-preview/
+          force: false

--- a/.github/workflows/pull_request_action.yml
+++ b/.github/workflows/pull_request_action.yml
@@ -1,5 +1,10 @@
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
     branches: main
 
 name: Test Rendering
@@ -50,4 +55,9 @@ jobs:
       - name: Build site 🔧
         run: |
           quarto render
+
+      - name: Deploy preview 🔍
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./_site/
     

--- a/index.qmd
+++ b/index.qmd
@@ -26,7 +26,7 @@ method_tbl <- read_csv("data/stat_method_tbl.csv", show_col_types = FALSE) |>
   mutate(link_name = str_extract(value, "(?<=^\\[).*(?=\\])"),
          link_loc = str_extract(value, "(?<=\\().*(?=\\)$)"),
          link = if_else(!is.na(value), 
-                        paste0('<a href=\"https://psiaims.github.io/CAMIS/',
+                        paste0('<a href=\"',
                        link_loc,
                        '.html">',
                        link_name, 


### PR DESCRIPTION
This PR updates the Pull Request and Deployment actions to allow for previews of the PR deployments.

It uses the action https://github.com/marketplace/actions/deploy-pr-preview, which I've called at the end of `.github/workflows/pull_request_action.yml`. This will upload the `_site` directory from the PR rendering output to a new `/pr-preview/pull-<n>` directory of the `gh-pages` branch, and create a sticky comment in the PR that links to this preview section of the site.

There is an example pull request for this at https://github.com/michaelwalshe/CAMIS/pull/1.

A couple of notes about this change:
 - The PR previews are currently *not* supported from forks, only from PR's from branches within the repo. This is a limitation, however allowing deploying artifacts to the repo from forks comes with fairly significant security risks (see https://github.com/rossjrw/pr-preview-action/pull/6). We could add support for this, by customising the action, however would increase maintenance (makes the action more complicated for us) and have the aforementioned security risks.
 - This implementation adds the previews to the main site, under a pr-preview subfolder. This won't be visible from the main site unless someone knows where to look (it isn't linked to). We could alternatively setup a second CAMIS-preview repository, with a separate github pages deployment, that the PR previews are uploaded to, however that again comes with some additional maintenance required.
 - There is a slight delay between the PR rendering finishing and the comment on the PR being created, and the page actually being visible. This is only a minute or so, but could confuse some contributors.

Happy to discuss further, this is only a sample implementation!