### PR TITLE
R code formatting in the `R/` folder

### DIFF
--- a/R/Accelerated_Failure_time_model.qmd
+++ b/R/Accelerated_Failure_time_model.qmd
@@ -1,7 +1,5 @@
 ---
 title: "Accelerated Failure Time Model"
-format: html
-editor: visual
 ---
 
 The accelerated failure time model is a parametric survival analysis technique used to model the relationship between the time to event of interest (e.g., time to failure) and a set of predictor variables. It assumes that the covariates have a multiplicative effect on the time to the event. In other words, the time to event is accelerated or decelerated by a factor that depends on the values of the covariates.This differs from the Cox proportional hazards model, which assumes that covariates have a multiplicative effect on the hazard rate, not the time to the event.
@@ -31,9 +29,10 @@ Where:
 ```{r}
 library(survival)
 attach(lung)
+
 # Fit an AFT model using lognormal distribution
-model_aft <- survreg(
-  Surv(time, status) ~ age + sex + ph.ecog,
+model_aft <- survival::survreg(
+  survival::Surv(time, status) ~ age + sex + ph.ecog,
   data = lung,
   dist = "lognormal"
 )
@@ -67,8 +66,8 @@ suppressPackageStartupMessages({
 })
 
 # Fit the AFT model on the lung dataset
-aft_model <- survreg(
-  Surv(time, status) ~ age + sex + ph.ecog,
+aft_model <- survival::survreg(
+  survival::Surv(time, status) ~ age + sex + ph.ecog,
   data = lung,
   dist = "lognormal"
 )
@@ -84,8 +83,8 @@ df <- data.frame(
 df$surv_times <- predict(aft_model, newdata = df)
 
 # Plot the survival curves based on the AFT model
-ggsurvplot(
-  survfit(Surv(surv_times, status) ~ 1, data = df),
+survminer::ggsurvplot(
+  survival::survfit(survival::Surv(surv_times, status) ~ 1, data = df),
   data = df,
   xlab = "Time",
   ylab = "Survival Probability"
@@ -98,8 +97,8 @@ The survival curve plotted based on the AFT model for the lung dataset illustrat
 
 ```{r}
 # Fit an AFT model using weibull distribution
-model_aft_wb <- survreg(
-  Surv(futime, fustat) ~ age + resid.ds + rx,
+model_aft_wb <- survival::survreg(
+  survival::Surv(futime, fustat) ~ age + resid.ds + rx,
   data = ovarian,
   dist = "weibull"
 )
@@ -128,8 +127,8 @@ acceleration_factor_wb
 ```{r}
 
 # Fit the AFT model (weibull distribution) on your data
-model_aft <- survreg(
-  Surv(futime, fustat) ~ age + resid.ds + rx,
+model_aft <- survival::survreg(
+  survival::Surv(futime, fustat) ~ age + resid.ds + rx,
   data = ovarian,
   dist = "weibull"
 )

--- a/R/Accelerated_Failure_time_model.qmd
+++ b/R/Accelerated_Failure_time_model.qmd
@@ -32,7 +32,11 @@ Where:
 library(survival)
 attach(lung)
 # Fit an AFT model using lognormal distribution
-model_aft <- survreg(Surv(time, status) ~ age + sex + ph.ecog, data = lung, dist = "lognormal")
+model_aft <- survreg(
+  Surv(time, status) ~ age + sex + ph.ecog,
+  data = lung,
+  dist = "lognormal"
+)
 # Model summary
 summary(model_aft)
 ```
@@ -57,21 +61,35 @@ acceleration_factor
 
 ```{r}
 suppressPackageStartupMessages({
-library(survival)
-library(survminer)
-library(ggplot2)
+  library(survival)
+  library(survminer)
+  library(ggplot2)
 })
 
 # Fit the AFT model on the lung dataset
-aft_model <- survreg(Surv(time, status) ~ age + sex + ph.ecog, data = lung, dist = "lognormal")
+aft_model <- survreg(
+  Surv(time, status) ~ age + sex + ph.ecog,
+  data = lung,
+  dist = "lognormal"
+)
 
 # Create a new data frame with predicted survival times
-df <- data.frame(time = lung$time, age = lung$age, sex = lung$sex, ph.ecog = lung$ph.ecog, status=lung$status)
+df <- data.frame(
+  time = lung$time,
+  age = lung$age,
+  sex = lung$sex,
+  ph.ecog = lung$ph.ecog,
+  status = lung$status
+)
 df$surv_times <- predict(aft_model, newdata = df)
 
 # Plot the survival curves based on the AFT model
-ggsurvplot(survfit(Surv(surv_times, status) ~ 1, data = df),
-           data = df, xlab = "Time", ylab = "Survival Probability")
+ggsurvplot(
+  survfit(Surv(surv_times, status) ~ 1, data = df),
+  data = df,
+  xlab = "Time",
+  ylab = "Survival Probability"
+)
 ```
 
 The survival curve plotted based on the AFT model for the lung dataset illustrates how the probability of survival changes as time progresses, showing the impact of different covariate levels on survival probabilities.
@@ -80,7 +98,11 @@ The survival curve plotted based on the AFT model for the lung dataset illustrat
 
 ```{r}
 # Fit an AFT model using weibull distribution
-model_aft_wb <- survreg(Surv(futime, fustat) ~ age + resid.ds + rx, data = ovarian, dist = "weibull")
+model_aft_wb <- survreg(
+  Surv(futime, fustat) ~ age + resid.ds + rx,
+  data = ovarian,
+  dist = "weibull"
+)
 # Model summary
 summary(model_aft_wb)
 ```
@@ -106,20 +128,37 @@ acceleration_factor_wb
 ```{r}
 
 # Fit the AFT model (weibull distribution) on your data
-model_aft <- survreg(Surv(futime, fustat) ~ age + resid.ds + rx, data = ovarian, dist = "weibull")
+model_aft <- survreg(
+  Surv(futime, fustat) ~ age + resid.ds + rx,
+  data = ovarian,
+  dist = "weibull"
+)
 
 # Create survival curves for different levels of predictor variables
-plot_data <- with(ovarian, data.frame(age = seq(min(age), max(age), length.out = 100),
-                                      resid.ds = mean(resid.ds),
-                                      rx = mean(rx)))
+plot_data <- with(
+  ovarian,
+  data.frame(
+    age = seq(min(age), max(age), length.out = 100),
+    resid.ds = mean(resid.ds),
+    rx = mean(rx)
+  )
+)
 
 # Predict survival times based on the AFT model
 plot_data$survival <- predict(model_aft, newdata = plot_data)
 
 # Plot the survival curves
-ggplot(plot_data, aes(x = age, y = survival, color = factor(rx), linetype = factor(rx))) +
+ggplot(
+  plot_data,
+  aes(x = age, y = survival, color = factor(rx), linetype = factor(rx))
+) +
   geom_line() +
-  labs(x = "Age", y = "Survival Probability", color = "Radiation Therapy", linetype = "Radiation Therapy") +
+  labs(
+    x = "Age",
+    y = "Survival Probability",
+    color = "Radiation Therapy",
+    linetype = "Radiation Therapy"
+  ) +
   scale_linetype_manual(values = c("solid", "dashed", "dotted")) +
   scale_color_manual(values = c("blue", "red", "green"))
 ```

--- a/R/Clustering_Knowhow.qmd
+++ b/R/Clustering_Knowhow.qmd
@@ -2,7 +2,6 @@
 title: "Clustering Data"
 author: "Niladri Dasgupta"
 date: "2024-08-12"
-output: html_document
 ---
 
 ```{r}
@@ -70,11 +69,11 @@ First, we’ll load below packages that contain several useful functions regardi
 
 ```{r}
 #| message: false
-library(cluster) #Contain cluster function
-library(dplyr) #Data manipulation
-library(ggplot2) #Plotting function
-library(readr) #Read and write excel/csv files
-library(factoextra) #Extract and Visualize the Results of Multivariate Data Analyses
+library(cluster) # Contain cluster function
+library(dplyr) # Data manipulation
+library(ggplot2) # Plotting function
+library(readr) # Read and write excel/csv files
+library(factoextra) # Extract and Visualize the Results of Multivariate Data Analyses
 ```
 
 **Step 2: Load Data**
@@ -83,10 +82,10 @@ We have used the “Mall_Customer” dataset in R for this case study.
 
 ```{r}
 #| message: false
-#Loading the data
+# Loading the data
 df <- read_csv("../data/Mall_Customers.csv")
 
-#Structure of the data
+# Structure of the data
 str(df)
 ```
 
@@ -94,21 +93,21 @@ dataset consists of 200 customers data with their age, annual income and Spendin
 
 ```{r}
 
-#Rename the columns
+# Rename the columns
 df <- df |>
   rename(
     "Annual_Income" = `Annual Income (k$)`,
     "Spending_score" = `Spending Score (1-100)`
   )
 
-#remove rows with missing values
+# remove rows with missing values
 df <- na.omit(df)
 
-#scale each variable to have a mean of 0 and sd of 1
+# scale each variable to have a mean of 0 and sd of 1
 df1 <- df |>
   mutate(across(where(is.numeric), scale))
 
-#view first six rows of dataset
+# view first six rows of dataset
 head(df1)
 
 ```
@@ -120,7 +119,6 @@ To create cluster with categorical or ordinal variable we can use k-Medoid clust
 
 ```{r}
 df1 <- df1[, 4:5]
-
 ```
 
 **Step 3: Find the Optimal Number of Clusters**
@@ -155,14 +153,13 @@ It has two parts as explained below-
 set.seed(1)
 wss <- NULL
 
-#Feeding different centroid/cluster and record WSS
-
+# Feeding different centroid/cluster and record WSS
 for (i in 1:10) {
-  fit = kmeans(df1, centers = i, nstart = 25)
+  fit = stats::kmeans(df1, centers = i, nstart = 25)
   wss = c(wss, fit$tot.withinss)
 }
 
-#Visualize the plot
+# Visualize the plot
 plot(1:10, wss, type = "o", xlab = 'Number of clusters(k)')
 
 ```
@@ -172,7 +169,7 @@ Based on the above plot at k=5 we can see an “elbow” where the sum of square
 The above process to compute the “Elbow method” has been wrapped up in a single function (fviz_nbclust):
 
 ```{r}
-fviz_nbclust(df1, kmeans, method = "wss", nstart = 25)
+factoextra::fviz_nbclust(df1, kmeans, method = "wss", nstart = 25)
 ```
 
 [**B. Silhouette Method:**]{.underline}
@@ -191,8 +188,8 @@ In this demonstration, we are going to see how silhouette method is used.
 ```{r}
 
 silhouette_score <- function(k) {
-  km <- kmeans(df1, centers = k, nstart = 25)
-  ss <- silhouette(km$cluster, dist(df1))
+  km <- stats::kmeans(df1, centers = k, nstart = 25)
+  ss <- cluster::silhouette(km$cluster, dist(df1))
   mean(ss[, 3])
 }
 k <- 2:10
@@ -213,7 +210,7 @@ From the above method we can see the silhouette width is highest at cluster 5 so
 Similar to the elbow method, this process to compute the “average silhoutte method” has been wrapped up in a single function (fviz_nbclust):
 
 ```{r}
-fviz_nbclust(df1, kmeans, method = 'silhouette', nstart = 25)
+factoextra::fviz_nbclust(df1, kmeans, method = 'silhouette', nstart = 25)
 ```
 
 The optimal number of clusters is 5.
@@ -223,34 +220,29 @@ The optimal number of clusters is 5.
 Lastly, we can perform k-means clustering on the dataset using the optimal value for k of 5:
 
 ```{r}
-
-#make this example reproducible
+# make this example reproducible
 set.seed(1)
 
-#perform k-means clustering with k = 5 clusters
-fit <- kmeans(df1, 5, nstart = 25)
-#view results
+# perform k-means clustering with k = 5 clusters
+fit <- stats::kmeans(df1, 5, nstart = 25)
 fit
 ```
 
 We can visualize the clusters on a scatterplot that displays the first two principal components on the axes using the fivz_cluster() function:
 
 ```{r}
-#plot results of final k-means model
-
-fviz_cluster(fit, data = df1)
+# plot results of final k-means model
+factoextra::fviz_cluster(fit, data = df1)
 ```
 
 **Step 5: Exporting the data by adding generated clusters**
 
 ```{r}
-#Adding the clusters in the main data
-
+# Adding the clusters in the main data
 df_cluster <- df |>
   mutate(cluster = fit$cluster)
 
-#Creating Summary of created clusters based on existing variables
-
+# Creating Summary of created clusters based on existing variables
 df_summary <- df_cluster |>
   group_by(cluster) |>
   summarise(

--- a/R/Clustering_Knowhow.qmd
+++ b/R/Clustering_Knowhow.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Clustering_knowhow"
+title: "Clustering Data"
 author: "Niladri Dasgupta"
 date: "2024-08-12"
 output: html_document
@@ -95,14 +95,17 @@ dataset consists of 200 customers data with their age, annual income and Spendin
 ```{r}
 
 #Rename the columns
-df <- df %>% 
-  rename("Annual_Income"= `Annual Income (k$)`, "Spending_score"= `Spending Score (1-100)`)
+df <- df |>
+  rename(
+    "Annual_Income" = `Annual Income (k$)`,
+    "Spending_score" = `Spending Score (1-100)`
+  )
 
 #remove rows with missing values
 df <- na.omit(df)
 
 #scale each variable to have a mean of 0 and sd of 1
-df1 <- df %>% 
+df1 <- df |>
   mutate(across(where(is.numeric), scale))
 
 #view first six rows of dataset
@@ -116,7 +119,7 @@ We have separated the CustomerID and Genre from the dataset. The reason for remo
 To create cluster with categorical or ordinal variable we can use k-Medoid clustering. <br>
 
 ```{r}
-df1 <- df1[,4:5]
+df1 <- df1[, 4:5]
 
 ```
 
@@ -150,17 +153,17 @@ It has two parts as explained below-
 
 ```{r}
 set.seed(1)
-wss<- NULL
+wss <- NULL
 
 #Feeding different centroid/cluster and record WSS
 
-for (i in 1:10){
-  fit = kmeans(df1,centers = i,nstart=25)
+for (i in 1:10) {
+  fit = kmeans(df1, centers = i, nstart = 25)
   wss = c(wss, fit$tot.withinss)
 }
 
 #Visualize the plot
-plot(1:10, wss, type = "o", xlab='Number of clusters(k)')
+plot(1:10, wss, type = "o", xlab = 'Number of clusters(k)')
 
 ```
 
@@ -169,7 +172,7 @@ Based on the above plot at k=5 we can see an “elbow” where the sum of square
 The above process to compute the “Elbow method” has been wrapped up in a single function (fviz_nbclust):
 
 ```{r}
-fviz_nbclust(df1, kmeans, method = "wss",nstart=25)
+fviz_nbclust(df1, kmeans, method = "wss", nstart = 25)
 ```
 
 [**B. Silhouette Method:**]{.underline}
@@ -187,15 +190,22 @@ In this demonstration, we are going to see how silhouette method is used.
 
 ```{r}
 
-silhouette_score <- function(k){
-  km <- kmeans(df1, centers = k,nstart = 25)
+silhouette_score <- function(k) {
+  km <- kmeans(df1, centers = k, nstart = 25)
   ss <- silhouette(km$cluster, dist(df1))
   mean(ss[, 3])
 }
 k <- 2:10
 
 avg_sil <- sapply(k, silhouette_score)
-plot(k, type='b', avg_sil, xlab='Number of clusters', ylab='Average Silhouette Scores', frame=FALSE)
+plot(
+  k,
+  type = 'b',
+  avg_sil,
+  xlab = 'Number of clusters',
+  ylab = 'Average Silhouette Scores',
+  frame = FALSE
+)
 ```
 
 From the above method we can see the silhouette width is highest at cluster 5 so the optimal number of cluster should be 5.
@@ -203,7 +213,7 @@ From the above method we can see the silhouette width is highest at cluster 5 so
 Similar to the elbow method, this process to compute the “average silhoutte method” has been wrapped up in a single function (fviz_nbclust):
 
 ```{r}
-fviz_nbclust(df1, kmeans, method='silhouette',nstart=25)
+fviz_nbclust(df1, kmeans, method = 'silhouette', nstart = 25)
 ```
 
 The optimal number of clusters is 5.
@@ -218,7 +228,7 @@ Lastly, we can perform k-means clustering on the dataset using the optimal value
 set.seed(1)
 
 #perform k-means clustering with k = 5 clusters
-fit <- kmeans(df1, 5, nstart=25)
+fit <- kmeans(df1, 5, nstart = 25)
 #view results
 fit
 ```
@@ -236,14 +246,19 @@ fviz_cluster(fit, data = df1)
 ```{r}
 #Adding the clusters in the main data
 
-df_cluster <- df %>% 
-  mutate(cluster=fit$cluster)
+df_cluster <- df |>
+  mutate(cluster = fit$cluster)
 
 #Creating Summary of created clusters based on existing variables
 
-df_summary <- df_cluster %>% 
-  group_by(cluster) %>% 
-  summarise(records=n(),avg_age=mean(Age),avg_annual_income=mean(Annual_Income),avg_spending_score=mean(Spending_score))
+df_summary <- df_cluster |>
+  group_by(cluster) |>
+  summarise(
+    records = n(),
+    avg_age = mean(Age),
+    avg_annual_income = mean(Annual_Income),
+    avg_spending_score = mean(Spending_score)
+  )
 
 print(df_summary)
 ```

--- a/R/PCA_analysis.qmd
+++ b/R/PCA_analysis.qmd
@@ -16,7 +16,7 @@ Principal Component Analysis (PCA) is a dimensionality reduction technique used 
 ```{r}
 library(factoextra)
 library(plotly)
-  
+
 data <- iris
 pca_result <- prcomp(data[, 1:4], scale = T)
 pca_result
@@ -43,9 +43,15 @@ fviz_eig(pca_result)
 A biplot shows the scores of the samples and the loadings of the variables on the first two principal components.
 
 ```{r}
-plt <- fviz_pca_biplot(pca_result, geom.ind = "point", pointshape = 21, 
-                pointsize = 2, fill.ind = iris$Species, 
-                col.var = "black", repel = TRUE)
+plt <- fviz_pca_biplot(
+  pca_result,
+  geom.ind = "point",
+  pointshape = 21,
+  pointsize = 2,
+  fill.ind = iris$Species,
+  col.var = "black",
+  repel = TRUE
+)
 plt
 ```
 
@@ -73,21 +79,22 @@ Next, we will create a dataframe of the 3 principle components and negate PC2 an
 
 ```{r}
 components <- as.data.frame(pca_result2$x)
-components$PC2 <- -components$PC2
-components$PC3 <- -components$PC3
+components$PC2 <- components$PC2
+components$PC3 <- components$PC3
 ```
 
 ```{r}
-fig <- plot_ly(components, 
-               x = ~PC1, 
-               y = ~PC2, 
-               z = ~PC3, 
-               color = ~data$Species, 
-               colors = c('darkgreen','darkblue','darkred')) %>%
+fig <- plot_ly(
+  components,
+  x = ~PC1,
+  y = ~PC2,
+  z = ~PC3,
+  color = ~ data$Species,
+  colors = c('darkgreen', 'darkblue', 'darkred')
+) |>
   add_markers(size = 12)
 
-fig <- fig %>%
-  layout(title = "3d Visualization of PCA",
-         scene = list(bgcolor = "lightgray"))
+fig <- fig |>
+  layout(title = "3d Visualization of PCA", scene = list(bgcolor = "lightgray"))
 fig
 ```

--- a/R/PCA_analysis.qmd
+++ b/R/PCA_analysis.qmd
@@ -1,7 +1,5 @@
 ---
 title: "Principle Component Analysis"
-format: html
-editor: visual
 ---
 
 ## Introduction
@@ -18,7 +16,7 @@ library(factoextra)
 library(plotly)
 
 data <- iris
-pca_result <- prcomp(data[, 1:4], scale = T)
+pca_result <- stats::prcomp(data[, 1:4], scale = T)
 pca_result
 ```
 
@@ -35,7 +33,7 @@ summary(pca_result)
 A scree plot shows the proportion of variance explained by each principal component.
 
 ```{r}
-fviz_eig(pca_result)
+factoextra::fviz_eig(pca_result)
 ```
 
 ### Biplot
@@ -43,7 +41,7 @@ fviz_eig(pca_result)
 A biplot shows the scores of the samples and the loadings of the variables on the first two principal components.
 
 ```{r}
-plt <- fviz_pca_biplot(
+plt <- factoextra::fviz_pca_biplot(
   pca_result,
   geom.ind = "point",
   pointshape = 21,
@@ -71,7 +69,7 @@ We will plot this using `plotly` package.
 
 ```{r}
 
-pca_result2 <- prcomp(data[, 1:4], scale = T, rank. = 3)
+pca_result2 <- stats::prcomp(data[, 1:4], scale = T, rank. = 3)
 pca_result2
 ```
 
@@ -84,7 +82,7 @@ components$PC3 <- components$PC3
 ```
 
 ```{r}
-fig <- plot_ly(
+fig <- plotly::plot_ly(
   components,
   x = ~PC1,
   y = ~PC2,

--- a/R/Weighted-log-rank.qmd
+++ b/R/Weighted-log-rank.qmd
@@ -43,7 +43,7 @@ library(haven)
 
 knitr::opts_chunk$set(echo = TRUE)
 
-dat <- read_sas(file.path("../data/whas500.sas7bdat"))
+dat <- haven::read_sas(file.path("../data/whas500.sas7bdat"))
 head(dat)
 ```
 
@@ -53,10 +53,11 @@ This function uses $G(\rho)=\hat{S}(t)^\rho, \rho \geq 0$ , where $\hat{S}(t)$ i
 
 ```{r}
 library(survival)
-WLRtest<-survdiff(Surv(LENFOL,FSTAT)~ AFB,rho = 3,data=dat)
-```
-
-```{r}
+WLRtest <- survival::survdiff(
+  survival::Surv(LENFOL, FSTAT) ~ AFB,
+  rho = 3,
+  data = dat
+)
 WLRtest
 ```
 
@@ -68,16 +69,22 @@ This function uses $G(\rho,\gamma)=\hat{S}(t)^\rho (1-\hat{S}(t))^\gamma; \rho,\
 
 ```{r}
 library(nphRCT)
-WL<-wlrt(Surv(LENFOL,FSTAT)~ AFB, data=dat, method="fh", rho = 0, gamma = 0)
+WL <- nphRCT::wlrt(
+  survival::Surv(LENFOL, FSTAT) ~ AFB,
+  data = dat,
+  method = "fh",
+  rho = 0,
+  gamma = 0
+)
 WL
 ```
 
 To obtain the corresponding $p$-value we can either use *2(1-pnorm(abs(WL\$z),0,1))* or we can square the test statistic *WL\$z* by using *(WL\$z)\^2* and obtain the corresponding $p$-values as *1 - pchisq((WL\$z)\^2,1)* , both the $p$-values will be the same.
 
 ```{r}
-2*(1-pnorm(abs(WL$z),0,1))
+2 * (1 - pnorm(abs(WL$z), 0, 1))
 (WL$z)^2
-1-pchisq((WL$z)^2,1)
+1 - pchisq((WL$z)^2, 1)
 ```
 
 For the illustration purpose we used $\rho=0,\  \gamma=0$ and in this scenario weighted log-rank test becomes standard log-rank test. Therefore, the result obtained in this illustration is consistent with the result obtained in [standard log-rank test](Survival%20Analysis%20Using%20R%20(psiaims.github.io)).
@@ -93,8 +100,10 @@ For the illustration purpose we used $\rho=0,\  \gamma=0$ and in this scenario w
 ```{r}
 #| echo: false
 si <- sessioninfo::session_info(
-  c("survival", "nphRCT") #Vector of packages used 
-  , dependencies = FALSE)
+  c("survival", "nphRCT"), #Vector of packages used
+  dependencies = FALSE
+)
 si
 ```
+
 :::

--- a/R/ancova.qmd
+++ b/R/ancova.qmd
@@ -84,11 +84,15 @@ model_tidy |>
 ```
 
 ```{r}
-model_table <-
-  model_ancova |>
+model_table <- model_ancova |>
   anova() |>
-  tidy() |>
-  add_row(term = "Total", df = sum(.$df), sumsq = sum(.$sumsq))
+  tidy()
+
+total_df <- sum(model_table$df)
+total_sumsq <- sum(model_table$sumsq)
+
+model_table |>
+  add_row(term = "Total", df = total_df, sumsq = total_sumsq)
 
 model_table |>
   gt()

--- a/R/ancova.qmd
+++ b/R/ancova.qmd
@@ -92,9 +92,7 @@ total_df <- sum(model_table$df)
 total_sumsq <- sum(model_table$sumsq)
 
 model_table |>
-  add_row(term = "Total", df = total_df, sumsq = total_sumsq)
-
-model_table |>
+  add_row(term = "Total", df = total_df, sumsq = total_sumsq) |>
   gt()
 ```
 

--- a/R/ancova.qmd
+++ b/R/ancova.qmd
@@ -15,7 +15,7 @@ library(emmeans)
 library(rstatix)
 library(gt)
 
-df_sas <- 
+df_sas <-
   tribble(
     ~drug, ~pre, ~post,
       "A",   11,     6,   
@@ -47,8 +47,9 @@ df_sas <-
       "F",   12,     5,   
       "F",   12,    16,   
       "F",    7,     1,   
-      "F",   12,    20) %>% 
+      "F",   12,    20) |>
   mutate(drug = factor(drug))
+
 my_formula <- as.formula(post ~ drug + pre)
 ```
 
@@ -63,61 +64,73 @@ We follow the example from link [Analysis of Covariance](https://documentation.s
 ## Data Summary
 
 ```{r}
-df_sas %>% glimpse()
-df_sas %>% summary()
+df_sas |> glimpse()
+df_sas |> summary()
 ```
 
 ## The Model
 
 ```{r}
 model_ancova <- lm(post ~ drug + pre, data = df_sas)
-model_glance <- model_ancova %>% glance()
-model_tidy   <- model_ancova %>% tidy()
-model_glance %>% gt()
-model_tidy   %>% gt()
+
+model_glance <- model_ancova |>
+  glance()
+model_tidy <- model_ancova |>
+  tidy()
+model_glance |>
+  gt()
+model_tidy |>
+  gt()
 ```
 
 ```{r}
-model_table <- 
-  model_ancova %>% 
-  anova() %>% 
-  tidy() %>% 
+model_table <-
+  model_ancova |>
+  anova() |>
+  tidy() |>
   add_row(term = "Total", df = sum(.$df), sumsq = sum(.$sumsq))
-model_table %>% gt()
+
+model_table |>
+  gt()
 ```
 
 ### Type 1
 
 ```{r}
-df_sas %>%
-  anova_test(post ~ drug + pre, type = 1, detailed = TRUE) %>% 
-  get_anova_table() %>%
+df_sas |>
+  anova_test(post ~ drug + pre, type = 1, detailed = TRUE) |>
+  get_anova_table() |>
   gt()
 ```
 
 ### Type 2
 
 ```{r}
-df_sas %>% 
-  anova_test(post ~ drug + pre, type = 2, detailed = TRUE) %>% 
-  get_anova_table() %>% 
+df_sas |>
+  anova_test(post ~ drug + pre, type = 2, detailed = TRUE) |>
+  get_anova_table() |>
   gt()
 ```
 
 ### Type 3
 
 ```{r}
-df_sas %>%
-  anova_test(post ~ drug + pre, type = 3, detailed = TRUE) %>% 
-  get_anova_table() %>% 
+df_sas |>
+  anova_test(post ~ drug + pre, type = 3, detailed = TRUE) |>
+  get_anova_table() |>
   gt()
 ```
 
 ### Least Squares Means
 
 ```{r}
-model_ancova %>% emmeans::lsmeans("drug") %>% emmeans::pwpm(pvals = TRUE, means = TRUE) 
-model_ancova %>% emmeans::lsmeans("drug") %>% plot(comparisons = TRUE)
+model_ancova |>
+  emmeans::lsmeans("drug") |>
+  emmeans::pwpm(pvals = TRUE, means = TRUE)
+
+model_ancova |>
+  emmeans::lsmeans("drug") |>
+  plot(comparisons = TRUE)
 ```
 
 ## sasLM Package

--- a/R/anova.qmd
+++ b/R/anova.qmd
@@ -81,7 +81,7 @@ This can be calculated using, the base R {stats} package or the {rstatix} packag
 
 ##### stats
 ```{r}
-anova(lm_model)
+stats::anova(lm_model)
 ```
 
 ##### rstatix 
@@ -108,7 +108,7 @@ This can be calculated using the {car} package or the {rstatix} package. Both gi
 
 ##### car
 ```{r}
-Anova(lm_model, type = "II")
+car::Anova(lm_model, type = "II")
 ```
 
 ##### rstatix 
@@ -159,7 +159,7 @@ lm_model <- lm(
 Using the base stats package, you can use the `drop1()` function which drops all possible single terms in a model. The scope term specifies how things can be dropped.
 
 ```{r}
-drop1(lm_model, scope = . ~ ., test = "F")
+stats::drop1(lm_model, scope = . ~ ., test = "F")
 ```
 
 ##### car

--- a/R/anova.qmd
+++ b/R/anova.qmd
@@ -8,9 +8,9 @@ ANOVA (Analysis of Variance) is a statistical method used to compare the means o
 
 The key assumptions include:
 
--   Independence of observations
--   Normality of the data (the distribution should be approximately normal)
--   Homogeneity of variances (similar variances across groups)
+-  Independence of observations
+-  Normality of the data (the distribution should be approximately normal)
+-  Homogeneity of variances (similar variances across groups)
 
 Common types include one-way ANOVA (one independent variable) and two-way ANOVA (two independent variables).
 
@@ -18,7 +18,7 @@ One-way ANOVA tests the effect of a single independent variable on a dependent v
 
 Two-way ANOVA tests the effect of two independent variables on a dependent variable and also examines if there is an interaction between the two independent variables.
 
-### **Getting Started**
+### Getting Started
 
 To demonstrate the various types of sums of squares, we'll create a data frame called `df_disease` taken from the SAS documentation. The corresponding data can be found [here](https://github.com/PSIAIMS/CAMIS/blob/main/data/sas_disease.csv).
 
@@ -33,12 +33,14 @@ library(car)
 
 knitr::opts_chunk$set(echo = TRUE)
 
-df_disease <- 
-  read_csv(
-    file = "../data/sas_disease.csv",
-    col_types = cols(drug    = col_factor(),
-                     disease = col_factor(),
-                     y       = col_double()))
+df_disease <- read_csv(
+  file = "../data/sas_disease.csv",
+  col_types = cols(
+    drug = col_factor(),
+    disease = col_factor(),
+    y = col_double()
+  )
+)
 ```
 
 ### The Model {.unnumbered}
@@ -46,20 +48,21 @@ df_disease <-
 For this example, we're testing for a significant difference in `stem_length` using ANOVA. Before getting the sums of squares and associated p-values from the ANOVA, we need to fit a linear model. In R, we're using `lm()` to fit the model, and then using `broom::glance()` and `broom::tidy()` to view the results in a table format.
 
 ```{r}
-lm_model <- lm(y ~ drug + disease + drug*disease, df_disease)
+lm_model <- lm(y ~ drug + disease + drug * disease, df_disease)
 ```
 
 The `glance` function gives us a summary of the model diagnostic values.
 
 ```{r}
-lm_model %>% 
-  glance() 
+lm_model |>
+  glance()
 ```
 
 The `tidy` function gives a summary of the model results.
 
 ```{r}
-lm_model %>% tidy()
+lm_model |>
+  tidy()
 ```
 
 
@@ -70,9 +73,9 @@ lm_model %>% tidy()
 Type I sums of square, also known as sequential ANOVA, is a method of analysis of variance where model terms are assessed sequentially. In this approach, the contribution of each factor or variable to the model is evaluated in the order they are specified, with each factor being adjusted for the effects of those that precede it. This means that the significance of a factor can depend on the factors that have already been included in the model. Type I ANOVA is useful for hierarchical models, where the sequence of entering factors into the model is meaningful or based on theoretical considerations. While possible to use on unbalanced designs it is often not testing the hypothesis of interest. 
 
 For a model with two factors, A and B (in that order) the sums of squares will be tested like this: 
-  - SS(A) for factor A. 
-  - SS(B | A) for factor B. 
-  - SS(AB | B, A) for interaction AB. 
+- SS(A) for factor A. 
+- SS(B | A) for factor B. 
+- SS(AB | B, A) for interaction AB. 
 
 This can be calculated using, the base R {stats} package or the {rstatix} package. Both give the same result. 
 
@@ -83,11 +86,12 @@ anova(lm_model)
 
 ##### rstatix 
 ```{r}
-df_disease %>% 
+df_disease |>
   rstatix::anova_test(
-    y ~ drug + disease + drug*disease, 
-    type = 1, 
-    detailed = TRUE)
+    y ~ drug + disease + drug * disease,
+    type = 1,
+    detailed = TRUE
+  )
 ```
 
 
@@ -96,8 +100,8 @@ df_disease %>%
 Type II sum of squares also known as hierarchical or partially sequential sums of squares. Tests the effect of adding a factor to the model after all other factors have been added. This means that the significance of a factor is assessed while controlling for the effects of all other factors in the model, but not for interactions. Type II ANOVA is particularly useful when there are no interactions in the model or when the focus is on main effects only. It is often used in unbalanced designs, where the number of observations varies across groups.
 
 For a model with two factors, A and B (in that order) the sums of squares will be tested like this: 
- - SS(A | B) for factor A. 
- - SS(B | A) for factor B. 
+- SS(A | B) for factor A. 
+- SS(B | A) for factor B. 
 
 This can be calculated using the {car} package or the {rstatix} package. Both give the same result.
 
@@ -109,11 +113,12 @@ Anova(lm_model, type = "II")
 
 ##### rstatix 
 ```{r}
-df_disease %>% 
+df_disease |>
   rstatix::anova_test(
-    y ~ drug + disease + drug*disease, 
-    type = 2, 
-    detailed = TRUE)
+    y ~ drug + disease + drug * disease,
+    type = 2,
+    detailed = TRUE
+  )
 ```
 
 
@@ -121,19 +126,19 @@ df_disease %>%
 
 Type III sum of squares is calculated such that every effect is adjusted for all other effect. This means testing for the presence of a main effect after adjusting for other main effects and interactions. 
 For a model with two factors, A and B (in that order) the sums of squares will be tested like this: 
- - SS(A | B, AB) for factor A. 
- - SS(B | A, AB) for factor B. 
+- SS(A | B, AB) for factor A. 
+- SS(B | A, AB) for factor B. 
 
 This can be calculated using the base R {stats} package, the {car} package or the {rstatix} package. All give the same result. 
 
 Note: Calculating type III sums of squares in R is a bit tricky, because the multi-way ANOVA model is over-paramerterised. So when running the linear model we need to select a design matrix that sums to zero. In R those options will be either `"contr.sum"` or `"contr.poly"`
 
 ```{r}
-# Drug design matrix 
-contr.sum(4) # Using 4 here as we have 4 levels of drug 
-# Disease design matrix 
-contr.sum(3) 
+# Drug design matrix
+contr.sum(4) # Using 4 here as we have 4 levels of drug
 
+# Disease design matrix
+contr.sum(3)
 ```
 
 While not relevant for this example as the disease variable isn't ordinal the polynomial design matrix would look like 
@@ -142,30 +147,37 @@ contr.poly(3)
 ```
 
 ```{r}
-lm_model <- lm(y ~ drug + disease + drug*disease, df_disease, 
-              contrasts = list(drug = "contr.sum", disease = "contr.sum"))
+lm_model <- lm(
+  y ~ drug + disease + drug * disease,
+  df_disease,
+  contrasts = list(drug = "contr.sum", disease = "contr.sum")
+)
 ```
 
 ##### stats
 
-Using the base stats package, you can use the `drop1()` function which drops all possible single terms in a model. The scope term specifies how things can be dropped. 
+Using the base stats package, you can use the `drop1()` function which drops all possible single terms in a model. The scope term specifies how things can be dropped.
+
 ```{r}
-drop1(lm_model, scope = .~., test="F")
+drop1(lm_model, scope = . ~ ., test = "F")
 ```
 
 ##### car
+
 ```{r}
 car::Anova(lm_model, type = "III")
 ```
 
 ##### rstatix 
 The `rstatix` package uses the `car` package to do the anova calculation, but can be nicer to use as it handles the contrasts for you and is more "pipe-able".
+
 ```{r}
-df_disease %>% 
+df_disease |>
   rstatix::anova_test(
-    y ~ drug + disease + drug*disease, 
-    type = 3, 
-    detailed = TRUE)
+    y ~ drug + disease + drug * disease,
+    type = 3,
+    detailed = TRUE
+  )
 ```
 
 
@@ -179,15 +191,16 @@ In R there is no equivalent operation to the `Type IV` sums of squares calculati
 The easiest way to get contrasts in R is by using `emmeans`. For looking at contrast we are going to fit a different model on new data, that doesn't include an interaction term as it is easier to calculate contrasts without an interaction term. For this dataset we have three different drugs A, C, and E.
 
 ```{r}
-df_trial<- read.csv("../data/drug_trial.csv")
+df_trial <- read.csv("../data/drug_trial.csv")
 
-lm(formula = post ~ pre + drug, data = df_trial) %>% 
-  emmeans("drug") %>% 
-  contrast(method = list(
-    "C vs A"  = c(-1,  1, 0),
-    "E vs CA" = c(-1, -1, 2)
-  ))
-
+lm(formula = post ~ pre + drug, data = df_trial) |>
+  emmeans("drug") |>
+  contrast(
+    method = list(
+      "C vs A" = c(-1, 1, 0),
+      "E vs CA" = c(-1, -1, 2)
+    )
+  )
 ```
 
 ## References

--- a/R/association.qmd
+++ b/R/association.qmd
@@ -42,14 +42,13 @@ glimpse(lung)
 We analyze the association between ECOG performance score (fully active vs any symptomatic patient) as rated by physician and weight loss (see `?lung` for details).
 
 ```{r}
-lung2 <- survival::lung %>% 
+lung2 <- survival::lung |> 
   mutate(
     ecog_grp = factor(ph.ecog > 0, labels = c("fully active", "symptomatic")), 
     wt_grp = factor(wt.loss > 0, labels = c("weight loss", "weight gain"))
   ) 
 
-(tab <- table(x = lung2$ecog_grp, y = lung2$wt_grp))
-
+tab <- table(x = lung2$ecog_grp, y = lung2$wt_grp)
 ```
 
 ## Chi-Squared test
@@ -71,7 +70,7 @@ fisher.test(tab)
 In a second example, we analyze the association between ECOG and Karnofky performance scores, both rated by physician (see `?lung` for details).
 
 ```{r}
-(tab2 <- table(x = lung2$ph.ecog, y = lung2$ph.karno))
+tab2 <- table(x = lung2$ph.ecog, y = lung2$ph.karno)
 ```
 
 ## Chi-Squared Test

--- a/R/binomial_test.qmd
+++ b/R/binomial_test.qmd
@@ -1,7 +1,5 @@
 ---
 title: "Binomial Test"
-format: html
-editor: visual
 ---
 
 The statistical test used to determine whether the proportion in a binary outcome experiment is equal to a specific value. It is appropriate when we have a small sample size and want to test the success probability $p$ against a hypothesized value $p_0$.
@@ -36,7 +34,7 @@ total_flips
 ## Conducting Binomial Test
 
 ```{r}
-binom_test_result <- binom.test(heads_count, total_flips, p = 0.5)
+binom_test_result <- stats::binom.test(heads_count, total_flips, p = 0.5)
 binom_test_result
 ```
 
@@ -68,7 +66,7 @@ total_pat
 We will conduct the Binomial test and hypothesize that the proportin of death should be 19%.
 
 ```{r}
-binom_test <- binom.test(num_deaths, total_pat, p = 0.19)
+binom_test <- stats::binom.test(num_deaths, total_pat, p = 0.19)
 binom_test
 ```
 

--- a/R/binomial_test.qmd
+++ b/R/binomial_test.qmd
@@ -14,23 +14,22 @@ The statistical test used to determine whether the proportion in a binary outcom
 
 ```{r}
 set.seed(19)
-coin_flips <- sample(c("H", "T"), 
-                     size = 1000, 
-                     replace = T,
-                     prob = c(0.5, 0.5))
+coin_flips <- sample(c("H", "T"), size = 1000, replace = T, prob = c(0.5, 0.5))
 ```
 
 Now, we will count the heads and tails and summarize the data.
 
 ```{r}
+# heads
 heads_count <- sum(coin_flips == "H")
-tails_count <- sum(coin_flips == "T")
-total_flips <- length(coin_flips)
-```
-
-```{r}
 heads_count
+
+# tails
+tails_count <- sum(coin_flips == "T")
 tails_count
+
+# total
+total_flips <- length(coin_flips)
 total_flips
 ```
 
@@ -55,12 +54,12 @@ We will calculate number of deaths and total number of patients.
 library(survival)
 attach(lung)
 
+# deaths
 num_deaths <- sum(lung$status == 1)
-total_pat <- nrow(lung)
-```
-
-```{r}
 num_deaths
+
+# total patients
+total_pat <- nrow(lung)
 total_pat
 ```
 

--- a/R/ci_for_prop.qmd
+++ b/R/ci_for_prop.qmd
@@ -28,29 +28,31 @@ The adcibc data stored [here](../data/adcibc.csv) was used in this example, crea
 library(tidyverse)
 library(cardx)
 library(DescTools)
-adcibc2<-read_csv("../data/adcibc.csv")
+adcibc2 <- read_csv("../data/adcibc.csv")
 
-adcibc<- adcibc2 %>% 
-        select(AVAL,TRTP) %>% 
-        mutate(resp=if_else(AVAL>4,"Yes","No")) %>% 
-        mutate(respn=if_else(AVAL>4,1,0)) %>% 
-        mutate(trt=if_else(TRTP=="Placebo","PBO","ACT"))%>% 
-        mutate(trtn=if_else(TRTP=="Placebo",0,1))%>% 
-        select(trt,trtn,resp, respn) 
+adcibc <- adcibc2 |>
+  select(AVAL, TRTP) |>
+  mutate(
+    resp = if_else(AVAL > 4, "Yes", "No"),
+    respn = if_else(AVAL > 4, 1, 0),
+    trt = if_else(TRTP == "Placebo", "PBO", "ACT"),
+    trtn = if_else(TRTP == "Placebo", 0, 1)
+  ) |>
+  select(trt, trtn, resp, respn)
 
 # cardx package required a vector with 0 and 1s for a single proportion CI
-act<-filter(adcibc,trt=="ACT") %>% 
-     select(respn)
-act2<-act$respn
+act <- filter(adcibc, trt == "ACT") |>
+  select(respn)
+act2 <- act$respn
 ```
 
 The below shows that for the Actual Treatment, there are 36 responders out of 154 subjects = 0.234 (23.4% responders).
 
 ```{r}
 #| echo: false
-adcibc %>% 
-  group_by(trt,resp) %>% 
-  tally() 
+adcibc |>
+  group_by(trt, resp) |>
+  tally()
 ```
 
 ## Packages
@@ -63,31 +65,9 @@ If calculating the CI for a difference in proportions, the package requires both
 
 Instead of the code presented below, you can use `ard_categorical_ci(data, variables=resp, method ='wilson')` for example. This invokes the code below but returns an analysis results dataset (ARD) format as the output. Methods included are waldcc, wald, clopper-pearson, wilson, wilsoncc, strat_wilson, strat_wilsoncc, agresti-coull and jeffreys for one-sample proportions and methods for 2 independent samples, however currently does not have a method for 2 matched proportions.
 
-Code example: `proportion_ci_clopper_pearson(<resp_var>,conf.level=0.95) %>%    as_tibble()`
-
-Example data format needed for {cardx} for a single proportion CI
-
-```{r}
-#| echo: false
-#Data for use with cardx takes the format 0s and 1s
-head(act2,30)
-```
-
-**The {PropCIs} package** produces CIs for methods such as Blaker's exact method and Midp which aren't available in {cardx} but are available in SAS. We found results agreed with SAS to the 5th decimal place. The package also calculates CIs for Clopper-Pearson, Wald, Wilson, Agresti-Coull and these align to results obtained in cardx to at least the 7th decimal place. The {PropsCIs} package requires just the number of events (numerator number of successes) & total number of subjects (denominator) as an input dataset. Given Blaker and Midp are rarely used in practice, and {PropsCIs} isn't a package commonly downloaded from CRAN, further detail is not provided here.
-
-Code example for Clopper-pearson:\
-`exactci(x=<count of successes> , n=<Total>, conf.level=0.95)`
-
-Code example for Mid P method:\
-`midPci(x=<count of successes> , n=<Total>, conf.level=0.95)`
-
-Code example for Blaker's exact method:\
-`blakerci(x=<count of successes> , n=<Total>, conf.level=0.95, tolerance=1e-05)`
+**The {PropCIs} package** produces CIs for methods such as Blaker's exact method and Midp which aren't available in {cardx} but are available in SAS. We found results agreed with SAS to the 5th decimal place. The package also calculates CIs for Clopper-Pearson, Wald, Wilson, Agresti-Coull and these align to results obtained in cardx to at least the 7th decimal place. The {PropsCIs} package requires just the number of events (numerator number of successes) & total number of subjects (denominator) as an input dataset. Given Blaker and Midp are rarely used in practice, and {PropsCIs} isn't a package commonly downloaded from CRAN, further details are not provided here.
 
 **The {Hmisc} package** produces CIs using the Clopper-Pearson method. In this example (x=36 and n=154), the results match the cardx package. Documentation reports that the method uses F distribution to compute exact intervals based on the binomial cdf. However, if the percentage of responders is 100% then the upper limit is set to 1. Similarly if the percentage of responders is 0%, then the lower limit is set to 0. Hence, in extreme cases there may be differences between this package and the standard implementation of Clopper-Pearson method.
-
-Code example for Clopper-pearson:\
-`binconf(x=<count of successes> , n=<Total>,method="exact",alpha=0.05)`
 
 **The {RBesT} package (Prior to Version 1.8-0)** produces CIs using the Clopper-Pearson method. In this example (x=36 and n=154), the results match the cardx package. However, as described below, there are 2 cases where the results using RBesT package do not match cardx or Hmisc.
 
@@ -106,13 +86,9 @@ In Version 1.8-0 onwards the equations were updated as follows, which then match
 pLow \<- qbeta(Low, r, n - r + 1)\
 pHigh \<- qbeta(High, r + 1, n - r)
 
-`BinaryExactCI(x=<count of successes> , n=<Total>,alpha=0.05)`
-
 **The {ExactCIdiff} package** produces exact CIs for two dependent proportions (matched pairs).
 
-**The {DescTools} package** has a function BinomDiffCI which produces CIs for two independent proportions (unmatched pairs) including methods for Agresti/Caffo, Wald, Wald with Continuity correction, Newcombe Score, Newcombe score with continuity correction, and more computationally intensive methods such as Miettinen and Nurminen, Mee, Brown Li's Jeffreys, Hauck-Anderson and Haldane. See [here](https://search.r-project.org/CRAN/refmans/DescTools/html/BinomDiffCI.html) for more detail. Code is of the form.
-
-`BinomDiffCI(x1, n1, x2, n2, conf.level = 0.95, sides =c("two.sided","left","right"),             method = c("ac", "wald", "waldcc", "score", "scorecc", "mn",                        "mee", "blj", "ha", "hal", "jp"))`
+**The {DescTools} package** has a function BinomDiffCI which produces CIs for two independent proportions (unmatched pairs) including methods for Agresti/Caffo, Wald, Wald with Continuity correction, Newcombe Score, Newcombe score with continuity correction, and more computationally intensive methods such as Miettinen and Nurminen, Mee, Brown Li's Jeffreys, Hauck-Anderson and Haldane. See [here](https://search.r-project.org/CRAN/refmans/DescTools/html/BinomDiffCI.html) for more detail. 
 
 **The {presize} package** has a function prec_prop() which also calculates CIs for 2 independent samples using the Wilson, Agresti-Coull, Exact or Wald approaches. The package is not described in further detail here since in most cases **{DescTools}** will be able to compute what is needed. However, it's mentioned due to other functionality it has available such as sample size and precision calculations for AUC, correlations, cronbach's alpha, intraclass correlation, Cohen's kappa, likelihood ratios, means, mean differences, odds ratios, rates, rate ratios, risk differences and risk ratios.
 
@@ -129,9 +105,8 @@ Clopper-Pearson Exact CI is one of the most popular methods, it is often good fo
 The cardx package calculates the Clopper-Pearson score by calling stats::binom.test() function.
 
 ```{r}
-proportion_ci_clopper_pearson(act2,conf.level=0.95) %>% 
+proportion_ci_clopper_pearson(act2, conf.level = 0.95) |>
   as_tibble()
-
 ```
 
 ### Normal Approximation Method (Also known as the Wald or asymptotic CI Method)
@@ -147,29 +122,33 @@ For more technical information see the corresponding [SAS page](https://psiaims.
 The following code calculates a confidence interval for a binomial proportion using normal approximation equation manually. This is replicated exactly using the `cardx::proportion_ci_wald function` which also allows the continuity correction to be applied.
 
 ```{r}
-    # sample proportion by trt
-summary <- adcibc %>% 
-           filter(trt=="ACT") %>% 
-           group_by(resp) %>% 
-           tally()  %>% 
-           ungroup() %>% 
-           mutate(total=sum(n)) %>% 
-           mutate(p=n/total)
+# sample proportion by trt
+summary <- adcibc |>
+  filter(trt == "ACT") |>
+  group_by(resp) |>
+  tally() |>
+  ungroup() |>
+  mutate(
+    total = sum(n),
+    p = n / total
+  )
 
-    # Calculate standard error and 95% wald confidence intervals for population proportion
-waldci <-summary %>% 
-         filter(resp=="Yes") %>% 
-         mutate(se=sqrt(p*(1-p)/total)) %>% 
-         mutate(lower_ci=(p-qnorm(1-0.05/2)*se)) %>% 
-         mutate(upper_ci=(p+qnorm(1-0.05/2)*se)) 
-waldci  
+# Calculate standard error and 95% wald confidence intervals for population proportion
+waldci <- summary |>
+  filter(resp == "Yes") |>
+  mutate(
+    se = sqrt(p * (1 - p) / total),
+    lower_ci = (p - qnorm(1 - 0.05 / 2) * se),
+    upper_ci = (p + qnorm(1 - 0.05 / 2) * se)
+  )
+waldci
 
-#cardx package Wald method without continuity correction
-proportion_ci_wald(act2,conf.level=0.95,correct=FALSE) %>% 
+# cardx package Wald method without continuity correction
+proportion_ci_wald(act2, conf.level = 0.95, correct = FALSE) |>
   as_tibble()
 
-#cardx package Wald method with continuity correction
-proportion_ci_wald(act2,conf.level=0.95,correct=TRUE) %>% 
+# cardx package Wald method with continuity correction
+proportion_ci_wald(act2, conf.level = 0.95, correct = TRUE) |>
   as_tibble()
 ```
 
@@ -180,13 +159,12 @@ The cardx package calculates the Wilson (score) method by calling stats::prop.te
 The package also contains a function for proportion_ci_strat_wilson() which calculates the stratified Wilson CIs for unequal proportions as described on page 47 [here](https://cran.r-universe.dev/cardx/cardx.pdf).
 
 ```{r}
-#cardx package Wilson method without continuity correction
-proportion_ci_wilson(act2,conf.level=0.95,correct=FALSE) %>% 
+# cardx package Wilson method without continuity correction
+proportion_ci_wilson(act2, conf.level = 0.95, correct = FALSE) |>
   as_tibble()
 
-
-#cardx package Wilson method with continuity correction
-proportion_ci_wilson(act2,conf.level=0.95,correct=TRUE) %>% 
+# cardx package Wilson method with continuity correction
+proportion_ci_wilson(act2, conf.level = 0.95, correct = TRUE) |>
   as_tibble()
 
 ```
@@ -196,11 +174,9 @@ proportion_ci_wilson(act2,conf.level=0.95,correct=TRUE) %>%
 The cardx package calculates the Agresti-Coull method using the equation from the published method by Alan Agresti & Brent Coull based on adding 2 successes and 2 failures before computing the wald CI. The CI is truncated, when it overshoots the boundary (\<0 or \>1).
 
 ```{r}
-
-#cardx package agresti_coull method 
-proportion_ci_agresti_coull(act2,conf.level=0.95) %>% 
+# cardx package agresti_coull method
+proportion_ci_agresti_coull(act2, conf.level = 0.95) |>
   as_tibble()
-
 ```
 
 ### Jeffreys Method
@@ -208,12 +184,9 @@ proportion_ci_agresti_coull(act2,conf.level=0.95) %>%
 Jeffreys method is a particular type of Bayesian Highest Probability Density (HPD) Method. For proportions, the beta distribution is generally used for the prior, which consists of two parameters alpha and beta. Setting alpha=beta=0.5 is called Jeffrey's prior. NOTE: if you want to use any other priors, you can use `binom.bayes` which estimates a credible interval for proportions.
 
 ```{r}
-#cardx package jeffreys method 
-proportion_ci_jeffreys(act2,conf.level=0.95) %>% 
+# cardx package jeffreys method
+proportion_ci_jeffreys(act2, conf.level = 0.95) |>
   as_tibble()
-```
-
-```         
 ```
 
 ## Methods for Calculating Confidence Intervals for a matched pair proportion using {ExactCIdiff}
@@ -261,12 +234,12 @@ Active: $\hat p_1 = (r+s)/n$ =35/46 =0.761 and Placebo: $\hat p_2= (r+t)/n$ = 26
 
 Difference = 0.761-0.565 = 0.196, then PairedCI() function can provide an exact confidence interval as shown below
 
-(-0.00339 to 0.38065)
+-0.00339 to 0.38065
 
 ```{r}
 #| eval: false
-#ExactCIdiff: PairedCI(s, r+u, t, conf.level = 0.95)
-CI<-PairedCI(15, 25, 6, conf.level = 0.95)$ExactCI
+# ExactCIdiff: PairedCI(s, r+u, t, conf.level = 0.95)
+CI <- PairedCI(15, 25, 6, conf.level = 0.95)$ExactCI
 CI
 ```
 
@@ -289,21 +262,35 @@ Both the Treatment variable (ACT,PBO) and the Response variable (Yes,No) have to
 The prop.test default with 2 groups, is the null hypothesis that the proportions in each group are the same and a 2-sided CI.
 
 ```{r}
-
-indat1<- adcibc2 %>% 
-  select(AVAL,TRTP) %>% 
-  mutate(resp=if_else(AVAL>4,"Yes","No")) %>% 
-  mutate(respn=if_else(AVAL>4,1,0)) %>% 
-  mutate(trt=if_else(TRTP=="Placebo","PBO","ACT"))%>% 
-  mutate(trtn=if_else(TRTP=="Placebo",1,0)) %>% 
-  select(trt,trtn,resp, respn) 
+indat1 <- adcibc2 |>
+  select(AVAL, TRTP) |>
+  mutate(
+    resp = if_else(AVAL > 4, "Yes", "No"),
+    respn = if_else(AVAL > 4, 1, 0),
+    trt = if_else(TRTP == "Placebo", "PBO", "ACT"),
+    trtn = if_else(TRTP == "Placebo", 1, 0)
+  ) |>
+  select(trt, trtn, resp, respn)
 
 # cardx package required a vector with 0 and 1s for a single proportion CI
 # To get the comparison the correct way around Placebo must be 1, and Active 0
 
-indat<- select(indat1, trtn,respn)
-cardx::ard_stats_prop_test(data=indat, by=trtn, variables=respn, conf.level = 0.95, correct=FALSE) 
-cardx::ard_stats_prop_test(data=indat, by=trtn, variables=respn, conf.level = 0.95, correct=TRUE) 
+indat <- select(indat1, trtn, respn)
+
+cardx::ard_stats_prop_test(
+  data = indat,
+  by = trtn,
+  variables = respn,
+  conf.level = 0.95,
+  correct = FALSE
+)
+cardx::ard_stats_prop_test(
+  data = indat,
+  by = trtn,
+  variables = respn,
+  conf.level = 0.95,
+  correct = TRUE
+)
 ```
 
 ### Normal Approximation (Wald) and Other Methods for 2 independent samples using {DescTools}
@@ -315,13 +302,35 @@ For more technical information regarding the derivations of these methods see th
 With 2 groups, the null hypothesis that the proportions in each group are the same and a 2-sided CI.
 
 ```{r}
-count_dat <- indat %>% 
-     count(trtn,respn)
+count_dat <- indat |>
+  count(trtn, respn)
 count_dat
-# the BinomDiffCI requires x1=successes in active, n1=total subjects in active,
-#                          x2=successes in placebo, n2=total subjects in placebo,
 
-BinomDiffCI(x1=36, n1=154, x2=12, n2=77, conf.level = 0.95, sides=c("two.sided"), method=c("wald","waldcc","score","scorecc","ac","mn","mee","blj","ha","hal","jp"))
+# BinomDiffCI requires
+# x1 = successes in active,  n1 = total subjects in active,
+# x2 = successes in placebo, n2 = total subjects in placebo
+
+BinomDiffCI(
+  x1 = 36,
+  n1 = 154,
+  x2 = 12,
+  n2 = 77,
+  conf.level = 0.95,
+  sides = c("two.sided"),
+  method = c(
+    "wald",
+    "waldcc",
+    "score",
+    "scorecc",
+    "ac",
+    "mn",
+    "mee",
+    "blj",
+    "ha",
+    "hal",
+    "jp"
+  )
+)
 ```
 
 ## References

--- a/R/ci_for_prop.qmd
+++ b/R/ci_for_prop.qmd
@@ -105,7 +105,7 @@ Clopper-Pearson Exact CI is one of the most popular methods, it is often good fo
 The cardx package calculates the Clopper-Pearson score by calling stats::binom.test() function.
 
 ```{r}
-proportion_ci_clopper_pearson(act2, conf.level = 0.95) |>
+cardx::proportion_ci_clopper_pearson(act2, conf.level = 0.95) |>
   as_tibble()
 ```
 
@@ -144,11 +144,11 @@ waldci <- summary |>
 waldci
 
 # cardx package Wald method without continuity correction
-proportion_ci_wald(act2, conf.level = 0.95, correct = FALSE) |>
+cardx::proportion_ci_wald(act2, conf.level = 0.95, correct = FALSE) |>
   as_tibble()
 
 # cardx package Wald method with continuity correction
-proportion_ci_wald(act2, conf.level = 0.95, correct = TRUE) |>
+cardx::proportion_ci_wald(act2, conf.level = 0.95, correct = TRUE) |>
   as_tibble()
 ```
 
@@ -160,11 +160,11 @@ The package also contains a function for proportion_ci_strat_wilson() which calc
 
 ```{r}
 # cardx package Wilson method without continuity correction
-proportion_ci_wilson(act2, conf.level = 0.95, correct = FALSE) |>
+cardx::proportion_ci_wilson(act2, conf.level = 0.95, correct = FALSE) |>
   as_tibble()
 
 # cardx package Wilson method with continuity correction
-proportion_ci_wilson(act2, conf.level = 0.95, correct = TRUE) |>
+cardx::proportion_ci_wilson(act2, conf.level = 0.95, correct = TRUE) |>
   as_tibble()
 
 ```
@@ -175,7 +175,7 @@ The cardx package calculates the Agresti-Coull method using the equation from th
 
 ```{r}
 # cardx package agresti_coull method
-proportion_ci_agresti_coull(act2, conf.level = 0.95) |>
+cardx::proportion_ci_agresti_coull(act2, conf.level = 0.95) |>
   as_tibble()
 ```
 
@@ -185,7 +185,7 @@ Jeffreys method is a particular type of Bayesian Highest Probability Density (HP
 
 ```{r}
 # cardx package jeffreys method
-proportion_ci_jeffreys(act2, conf.level = 0.95) |>
+cardx::proportion_ci_jeffreys(act2, conf.level = 0.95) |>
   as_tibble()
 ```
 
@@ -238,8 +238,9 @@ Difference = 0.761-0.565 = 0.196, then PairedCI() function can provide an exact 
 
 ```{r}
 #| eval: false
-# ExactCIdiff: PairedCI(s, r+u, t, conf.level = 0.95)
-CI <- PairedCI(15, 25, 6, conf.level = 0.95)$ExactCI
+# ExactCIdiff::PairedCI(s, r+u, t, conf.level = 0.95)
+
+CI <- ExactCIdiff::PairedCI(15, 25, 6, conf.level = 0.95)$ExactCI
 CI
 ```
 
@@ -310,7 +311,7 @@ count_dat
 # x1 = successes in active,  n1 = total subjects in active,
 # x2 = successes in placebo, n2 = total subjects in placebo
 
-BinomDiffCI(
+DescTools::BinomDiffCI(
   x1 = 36,
   n1 = 154,
   x2 = 12,

--- a/R/cmh.qmd
+++ b/R/cmh.qmd
@@ -51,9 +51,11 @@ This is included in a base installation of R, as part of the stats package. Requ
 # 2x2x2 example
 data2 <- data |>
   filter(TRTPN != "54" & AGEGR1 != ">80")
-mantelhaen.test(x = data2$TRTP, y = data2$SEX, z = data2$AGEGR1)
+
+stats::mantelhaen.test(x = data2$TRTP, y = data2$SEX, z = data2$AGEGR1)
+
 # 3x2x3 example
-mantelhaen.test(x = data$TRTP, y = data$SEX, z = data$AGEGR1)
+stats::mantelhaen.test(x = data$TRTP, y = data$SEX, z = data$AGEGR1)
 ```
 
 ### vcdExtra
@@ -62,8 +64,9 @@ The vcdExtra package provides results for the generalized CMH test, for each of 
 
 ```{r}
 library(vcdExtra)
+
 # Formula: Freq ~ X + Y | K
-CMHtest(Freq ~ TRTP + SEX | AGEGR1, data = data, overall = TRUE)
+vcdExtra::CMHtest(Freq ~ TRTP + SEX | AGEGR1, data = data, overall = TRUE)
 ```
 
 ### epiDisplay
@@ -73,7 +76,7 @@ To get the M-H common odds ratio and the homogeneity test, the epiDisplay packag
 ```{r}
 #| eval: false
 library(epiDisplay)
-mhor(x, y, k, graph = FALSE)
+epiDisplay::mhor(x, y, k, graph = FALSE)
 ```
 
 #### Forked Version - Solution for sparse data

--- a/R/cmh.qmd
+++ b/R/cmh.qmd
@@ -26,7 +26,7 @@ tribble(
   ~Package, ~`General Association`, ~`Row Means Differ`, ~`Nonzero Correlation`, ~`M-H Odds Ratio`, ~`Homogeneity Test`, ~Note,
  "stats::mantelhaen.test()", yes, no, no, yes, no, "Works well for 2x2xK",
  "vcdExtra::CMHtest()", yes,yes,yes,no,no,"Problems with sparsity, potential bug",
- "epiDisplay::mhor()", no,no,no,yes,yes,"OR are limited to 2x2xK design") %>%
+ "epiDisplay::mhor()", no,no,no,yes,yes,"OR are limited to 2x2xK design") |>
   gt::gt()
 ```
 
@@ -36,7 +36,7 @@ We will use the CDISC Pilot data set, which is publicly available on the PHUSE T
 
 ```{r}
 #| echo: false
-data<-read.csv("../data/adcibc.csv")
+data <- read.csv("../data/adcibc.csv")
 head(data)
 
 ```
@@ -48,11 +48,11 @@ head(data)
 This is included in a base installation of R, as part of the stats package. Requires inputting data as a *table* or as *vectors*. Two examples 2x2x2 examples: X=2 treatments, Y=Sex (M/F), controlling for 2 age groups and 3x2x3 example X=3 treatments, Y=Sex (M/F), controlling for 3 age groups.
 
 ```{r}
-#2x2x2 example
-data2 <- data %>% 
-         filter(TRTPN !="54" & AGEGR1 !=">80")
+# 2x2x2 example
+data2 <- data |>
+  filter(TRTPN != "54" & AGEGR1 != ">80")
 mantelhaen.test(x = data2$TRTP, y = data2$SEX, z = data2$AGEGR1)
-#3x2x3 example
+# 3x2x3 example
 mantelhaen.test(x = data$TRTP, y = data$SEX, z = data$AGEGR1)
 ```
 
@@ -63,7 +63,7 @@ The vcdExtra package provides results for the generalized CMH test, for each of 
 ```{r}
 library(vcdExtra)
 # Formula: Freq ~ X + Y | K
-CMHtest(Freq ~ TRTP + SEX | AGEGR1 , data=data, overall=TRUE) 
+CMHtest(Freq ~ TRTP + SEX | AGEGR1, data = data, overall = TRUE)
 ```
 
 ### epiDisplay
@@ -72,8 +72,8 @@ To get the M-H common odds ratio and the homogeneity test, the epiDisplay packag
 
 ```{r}
 #| eval: false
-library(epiDisplay) 
-mhor(x,y,k, graph = FALSE)
+library(epiDisplay)
+mhor(x, y, k, graph = FALSE)
 ```
 
 #### Forked Version - Solution for sparse data

--- a/R/correlation.qmd
+++ b/R/correlation.qmd
@@ -3,8 +3,8 @@ title: "Correlation Analysis Using R"
 ---
 
 ```{r}
-#| echo: FALSE
-#| include: FALSE
+#| echo: false
+#| include: false
 library(tidyverse)
 ```
 
@@ -63,13 +63,13 @@ Missing values are assumed to be missing completely at random (MCAR). Different 
 # Pearson Correlation
 
 ```{r}
-cor.test(x = lung$age, y = lung$meal.cal, method = "pearson")
+stats::cor.test(x = lung$age, y = lung$meal.cal, method = "pearson")
 ```
 
 # Spearman Correlation
 
 ```{r}
-cor.test(x = lung$age, y = lung$meal.cal, method = "spearman")
+stats::cor.test(x = lung$age, y = lung$meal.cal, method = "spearman")
 ```
 
 Note: Exact p-values require unanimous ranks.
@@ -77,7 +77,7 @@ Note: Exact p-values require unanimous ranks.
 # Kendall's rank correlation
 
 ```{r}
-cor.test(x = lung$age, y = lung$meal.cal, method = "kendall")
+stats::cor.test(x = lung$age, y = lung$meal.cal, method = "kendall")
 ```
 
 # Interpretation of correlation coefficients

--- a/R/correlation.qmd
+++ b/R/correlation.qmd
@@ -47,7 +47,7 @@ Other association measures are available for count data/contingency tables compa
 Survival in patients with advanced lung cancer from the North Central Cancer Treatment Group. Performance scores rate how well the patient can perform usual daily activities.
 
 ```{r}
-library(survival) 
+library(survival)
 
 glimpse(lung)
 ```
@@ -63,7 +63,7 @@ Missing values are assumed to be missing completely at random (MCAR). Different 
 # Pearson Correlation
 
 ```{r}
-cor.test(x = lung$age, y = lung$meal.cal, method = "pearson") 
+cor.test(x = lung$age, y = lung$meal.cal, method = "pearson")
 ```
 
 # Spearman Correlation
@@ -89,5 +89,3 @@ Correlation coefficient is comprised between -1 and 1:
 -   $0$ means that there is no association between the two variables
 
 -   $1$ indicates a strong positive correlation
-
-# 

--- a/R/count_data_regression.qmd
+++ b/R/count_data_regression.qmd
@@ -47,7 +47,7 @@ We fit a generalized linear model for `number` using the Poisson distribution wi
 
 ```{r}
 # Poisson
-m1 <- glm(number ~ treat + age, data = polyps, family = poisson)
+m1 <- stats::glm(number ~ treat + age, data = polyps, family = poisson)
 summary(m1)
 ```
 
@@ -73,7 +73,7 @@ Poisson model assumes that mean and variance are equal, which can be a very rest
 
 ```{r}
 # Quasi poisson
-m2 <- glm(number ~ treat + age, data = polyps, family = quasipoisson)
+m2 <- stats::glm(number ~ treat + age, data = polyps, family = quasipoisson)
 summary(m2)
 ```
 

--- a/R/count_data_regression.qmd
+++ b/R/count_data_regression.qmd
@@ -3,8 +3,8 @@ title: "Regression for Count Data"
 ---
 
 ```{r}
-#| echo: FALSE
-#| include: FALSE
+#| echo: false
+#| include: false
 library(tidyverse)
 ```
 
@@ -35,9 +35,10 @@ glimpse(polyps)
 We analyze the number of colonic polyps at 12 months in dependency of treatment and age of the patient.
 
 ```{r}
-polyps %>% 
-  ggplot(aes(y = number, x = age, color = treat)) + 
-  geom_point() + theme_minimal()
+polyps |>
+  ggplot(aes(y = number, x = age, color = treat)) +
+  geom_point() +
+  theme_minimal()
 ```
 
 # Model Fit
@@ -62,7 +63,7 @@ Predictions for number of colonic polyps given a new 25-year-old patient on eith
 
 ```{r}
 # new 25 year old patient
-new_pt <- data.frame(treat = c("drug","placebo"), age=25)
+new_pt <- data.frame(treat = c("drug", "placebo"), age = 25)
 predict(m1, new_pt, type = "response")
 ```
 

--- a/R/friedman_test.qmd
+++ b/R/friedman_test.qmd
@@ -20,7 +20,7 @@ Friedman’s test ranks the data points within each block (or subject) separatel
 # Load required packages
 library(tidyverse)
 library(broom)
-library(rstatix) 
+library(rstatix)
 
 ```
 
@@ -43,7 +43,7 @@ Diet_C = c(78, 65, 82, 75, 84, 72, 80, 76, 77, 84)
 
 data <- tibble(
   subjid = rep(1:10, 3),
-  diet = rep(c("A", "B", "C"), each = 10), 
+  diet = rep(c("A", "B", "C"), each = 10),
   weight = c(Diet_A, Diet_B, Diet_C)
 )
 
@@ -62,6 +62,7 @@ friedman_test <- friedman.test(weight ~ diet | subjid, data = data)
 friedman_test
 
 ```
+
 To get these values easily into a data.frame you can use the `tidy()` function from {broom}.
 ```{r}
 tidy(friedman_test)
@@ -71,7 +72,7 @@ tidy(friedman_test)
 
 Alternatively, you can use the {rstatix} package. While these packages give the same results, the {rstatix} results come as a tibble we can easily use. 
 ```{r}
-test <- data %>% 
+test <- data |>
   friedman_test(weight ~ diet | subjid)
 test
 ```
@@ -86,9 +87,11 @@ test
 ggplot(data, aes(x = diet, y = weight, fill = diet)) +
   geom_boxplot() +
   theme_minimal() +
-  labs(title = "Weight Distribution Across Different Diets",
-       x = "Diet Type",
-       y = "Weight") 
+  labs(
+    title = "Weight Distribution Across Different Diets",
+    x = "Diet Type",
+    y = "Weight"
+  )
 
 ```
 
@@ -128,14 +131,15 @@ If p \> 0.05, we fail to reject the null hypothesis\]
 ::: {.callout-note collapse="true" title="Session Info"}
 ```{r}
 #| echo: false
-# List all the packages needed 
+# List all the packages needed
 si <- sessioninfo::session_info(c(
-  #Create a vector of all the packages used in this file 
+  #Create a vector of all the packages used in this file
   "tidyverse",
   "broom",
   "rstatix"
 ))
 si
 ```
+
 :::
 

--- a/R/friedman_test.qmd
+++ b/R/friedman_test.qmd
@@ -1,7 +1,6 @@
 ---
 title: "Friedman Test Analysis"
 date: "2025-04-09"
-output: html_document
 ---
 
 ## Friedman Test Analysis
@@ -13,9 +12,9 @@ Friedman’s test ranks the data points within each block (or subject) separatel
 
 ```{r}
 #| label: load-packages
-#| message: FALSE
-#| warning: FALSE
-#| eval: TRUE
+#| message: false
+#| warning: false
+#| eval: true
 
 # Load required packages
 library(tidyverse)
@@ -56,16 +55,9 @@ To run a Friedman's test in R you can use the {stats} package. This will return 
 #| label: friedman-test
 
 # Perform Friedman test
-
-friedman_test <- friedman.test(weight ~ diet | subjid, data = data)
-
-friedman_test
-
-```
-
-To get these values easily into a data.frame you can use the `tidy()` function from {broom}.
-```{r}
-tidy(friedman_test)
+friedman_test <- stats::friedman.test(weight ~ diet | subjid, data = data)
+friedman_test |>
+  broom::tidy()
 ```
 
 ### {rstatix}
@@ -73,7 +65,7 @@ tidy(friedman_test)
 Alternatively, you can use the {rstatix} package. While these packages give the same results, the {rstatix} results come as a tibble we can easily use. 
 ```{r}
 test <- data |>
-  friedman_test(weight ~ diet | subjid)
+  rstatix::friedman_test(weight ~ diet | subjid)
 test
 ```
 
@@ -83,7 +75,6 @@ test
 #| fig-height: 6
 
 # Create boxplot
-
 ggplot(data, aes(x = diet, y = weight, fill = diet)) +
   geom_boxplot() +
   theme_minimal() +

--- a/R/gsd-tte.qmd
+++ b/R/gsd-tte.qmd
@@ -12,6 +12,16 @@ While a group sequential design (GSD) could be applied for different types of en
 
 The commonly used R packages for power and sample size calculations utilizing a GSD are: [gsDesign](https://keaven.github.io/gsDesign/) (also has a [web interface](https://rinpharma.shinyapps.io/gsdesign/)), [gsDesign2](https://merck.github.io/gsDesign2/), and [rpact](https://www.rpact.org/).
 
+
+```{r}
+#| warning: false
+#| message: false
+library(gsDesign)
+library(gsDesign2)
+library(rpact)
+library(tibble)
+```
+
 ## Design assumptions
 
 Using a toy example, we will assume that a primary objective of a phase III oncology trial is to compare a new therapy to a control in terms of progression-free survival (PFS) and overall survival (OS). Note that, in this example, we have a family of primary endpoints, i.e., if at least one of the endpoints is successful, the study will be declared a success. A GSD will be utilized for each endpoint. PFS will be tested at one interim analysis (IA) for both efficacy and non-binding futility, while OS will be tested at two IAs for efficacy only. An O'Brien-Fleming spending function will be used for efficacy testing and a Hwang-Shih-Decani spending function with $\gamma = -10$ will be used for futility.
@@ -62,13 +72,7 @@ We assume that given the above assumptions, we need to calculate the target numb
 -   PFS calculations:
 
 ```{r}
-#| warning: false
-#| message: false
-library(gsDesign)
-```
-
-```{r}
-pfs_gsDesign <- gsSurv(
+pfs_gsDesign <- gsDesign::gsSurv(
   k = length(timing_pfs),
   timing = timing_pfs,
   R = enroll_dur,
@@ -85,13 +89,14 @@ pfs_gsDesign <- gsSurv(
   test.type = 4
 )
 
-pfs_gsDesign |> gsBoundSummary()
+pfs_gsDesign |>
+  gsDesign::gsBoundSummary()
 ```
 
 -   OS calculations:
 
 ```{r}
-os_gsDesign <- gsSurv(
+os_gsDesign <- gsDesign::gsSurv(
   k = length(timing_os),
   timing = timing_os,
   R = enroll_dur,
@@ -106,19 +111,13 @@ os_gsDesign <- gsSurv(
   test.type = 1
 )
 
-os_gsDesign |> gsBoundSummary()
+os_gsDesign |>
+  gsDesign::gsBoundSummary()
 ```
 
 ### Example using gsDesign2
 
 -   PFS calculations:
-
-```{r}
-#| warning: false
-#| message: false
-library(gsDesign2)
-library(tibble)
-```
 
 ```{r}
 enroll_rate <- tibble(
@@ -134,7 +133,7 @@ fail_rate_pfs <- tibble(
   dropout_rate = do_rate_pfs
 )
 
-pfs_gsDesign2 <- gs_design_ahr(
+pfs_gsDesign2 <- gsDesign2::gs_design_ahr(
   enroll_rate = enroll_rate,
   fail_rate = fail_rate_pfs,
   ratio = rand_ratio,
@@ -173,7 +172,7 @@ fail_rate_os <- tibble(
   dropout_rate = do_rate_os
 )
 
-os_gsDesign2 <- gs_design_ahr(
+os_gsDesign2 <- gsDesign2::gs_design_ahr(
   enroll_rate = pfs_gsDesign2$enroll_rate,
   fail_rate = fail_rate_os,
   ratio = rand_ratio,
@@ -200,13 +199,7 @@ os_gsDesign2 |>
 -   PFS calculations:
 
 ```{r}
-#| warning: false
-#| message: false
-library(rpact)
-```
-
-```{r}
-pfs_rpact_gsd <- getDesignGroupSequential(
+pfs_rpact_gsd <- rpact::getDesignGroupSequential(
   sided = 1,
   alpha = alphal,
   informationRates = timing_pfs,
@@ -217,7 +210,7 @@ pfs_rpact_gsd <- getDesignGroupSequential(
   bindingFutility = FALSE
 )
 
-pfs_rpact <- getSampleSizeSurvival(
+pfs_rpact <- rpact::getSampleSizeSurvival(
   design = pfs_rpact_gsd,
   accrualTime = enroll_dur,
   followUpTime = minfu_pfs,
@@ -237,7 +230,7 @@ Note: the `dropoutRate1`, `dropoutRate2` arguments in `getSampleSizeSurvival()` 
 
 ```{r}
 #| warning: false
-os_rpact_gsd <- getDesignGroupSequential(
+os_rpact_gsd <- rpact::getDesignGroupSequential(
   sided = 1,
   alpha = alphal,
   informationRates = timing_os,
@@ -245,7 +238,7 @@ os_rpact_gsd <- getDesignGroupSequential(
   beta = 1 - power_os
 )
 
-os_rpact <- getSampleSizeSurvival(
+os_rpact <- rpact::getSampleSizeSurvival(
   design = os_rpact_gsd,
   accrualTime = enroll_dur,
   followUpTime = minfu_os,

--- a/R/jonckheere.qmd
+++ b/R/jonckheere.qmd
@@ -36,7 +36,6 @@ set.seed(4989)
 
 inds <- read_csv("../data/jonck.csv", col_select = c(DOSE, value))
 
-
 jt_norm <- DescTools::JonckheereTerpstraTest(
   value ~ DOSE,
   alternative = "decreasing",

--- a/R/jonckheere.qmd
+++ b/R/jonckheere.qmd
@@ -29,25 +29,20 @@ library(DescTools)
 library(ggplot2)
 library(readr)
 
-#
 # Constants
 k_n_samp <- 10000
 
 set.seed(4989)
-#
-# The input dataset is imported.
-#
-inds <- read_csv("../data/jonck.csv", col_select = c(DOSE, value)) 
-  
 
-#
-# Analysis
-#
+inds <- read_csv("../data/jonck.csv", col_select = c(DOSE, value))
+
+
 jt_norm <- DescTools::JonckheereTerpstraTest(
   value ~ DOSE,
   alternative = "decreasing",
   data = inds
 )
+jt_norm
 
 jt_resamp <- DescTools::JonckheereTerpstraTest(
   value ~ DOSE,
@@ -55,14 +50,9 @@ jt_resamp <- DescTools::JonckheereTerpstraTest(
   data = inds,
   nperm = k_n_samp
 )
-
-jt_norm
 jt_resamp
 
-
 ```
-
-
 
 ## Reference
 

--- a/R/kruskal_wallis.qmd
+++ b/R/kruskal_wallis.qmd
@@ -26,7 +26,7 @@ print(iris_sub)
 The Kruskal-Wallis test can be implemented in R using stats::kruskal.test. Below, the test is defined using R's formula interface (dependent \~ independent variable) and specifying the data set. The null hypothesis is that the samples are from identical populations.
 
 ```{r}
-kruskal.test(Sepal_Width ~ Species, data = iris_sub)
+stats::kruskal.test(Sepal_Width ~ Species, data = iris_sub)
 ```
 
 ## Results

--- a/R/kruskal_wallis.qmd
+++ b/R/kruskal_wallis.qmd
@@ -8,11 +8,14 @@ The Kruskal-Wallis test is a non-parametric equivalent to the one-way ANOVA. For
 
 ```{r}
 #| echo: false
-species_n <- c('setosa','versicolor','virginica')
+species_n <- c('setosa', 'versicolor', 'virginica')
+# fmt: skip
 iris_sub <- data.frame(
-  Species = c(rep(species_n, each=6)),
-  Sepal_Width = c(3.4, 3.0, 3.4, 3.2, 3.5, 3.1, 2.7, 2.9, 2.7, 2.6, 2.5, 2.5,
-                  3.0, 3.0, 3.1, 3.8, 2.7, 3.3)
+  Species = c(rep(species_n, each = 6)),
+  Sepal_Width = c(
+    3.4, 3.0, 3.4, 3.2, 3.5, 3.1, 2.7, 2.9, 2.7, 
+    2.6, 2.5, 2.5, 3.0, 3.0, 3.1, 3.8, 2.7, 3.3
+  )
 )
 
 print(iris_sub)
@@ -23,7 +26,7 @@ print(iris_sub)
 The Kruskal-Wallis test can be implemented in R using stats::kruskal.test. Below, the test is defined using R's formula interface (dependent \~ independent variable) and specifying the data set. The null hypothesis is that the samples are from identical populations.
 
 ```{r}
-kruskal.test(Sepal_Width~Species, data=iris_sub)
+kruskal.test(Sepal_Width ~ Species, data = iris_sub)
 ```
 
 ## Results

--- a/R/linear-regression.qmd
+++ b/R/linear-regression.qmd
@@ -1,6 +1,5 @@
 ---
 title: "Linear Regression"
-output: html_document
 ---
 
 ## Introduction

--- a/R/linear-regression.qmd
+++ b/R/linear-regression.qmd
@@ -26,14 +26,14 @@ The first step is to obtain the simple descriptive statistics for the numeric va
 
 ```{r}
 knitr::opts_chunk$set(echo = TRUE)
-htwt<-read.csv("../data/htwt.csv")
+htwt <- read.csv("../data/htwt.csv")
 summary(htwt)
 ```
 
 In order to create a regression model to demonstrate the relationship between age and height for females, we first need to create a flag variable identifying females and an interaction variable between age and female gender flag.
 
 ```{r}
-htwt$female <- ifelse(htwt$SEX=='f',1,0)
+htwt$female <- ifelse(htwt$SEX == 'f', 1, 0)
 htwt$fem_age <- htwt$AGE * htwt$female
 head(htwt)
 ```
@@ -43,13 +43,13 @@ head(htwt)
 Next, we fit a regression model, representing the relationships between gender, age, height and the interaction variable created in the datastep above. We again use a where statement to restrict the analysis to those who are less than or equal to 19 years old. We use the clb option to get a 95% confidence interval for each of the parameters in the model. The model that we are fitting is $height = b_0 + b_1\times female + b_2\times age + b_3\times fem\_age + e$
 
 ```{r}
-regression<-lm(HEIGHT~female+AGE+fem_age, data=htwt, AGE<=19)
+regression <- lm(HEIGHT ~ female + AGE + fem_age, data = htwt, AGE <= 19)
 summary(regression)
 
-b0=round(regression$coefficients[1],4)
-b1=round(regression$coefficients[2],4)
-b2=round(regression$coefficients[3],4)
-b3=round(regression$coefficients[4],4)
+b0 = round(regression$coefficients[1], 4)
+b1 = round(regression$coefficients[2], 4)
+b2 = round(regression$coefficients[3], 4)
+b3 = round(regression$coefficients[4], 4)
 
 ```
 

--- a/R/logistic_regr.qmd
+++ b/R/logistic_regr.qmd
@@ -63,7 +63,6 @@ A factor with 2 levels (2 treatments) using `contr.treatment` would set the firs
 A factor with 4 levels (4 treatments) using `contr.treatment` would set the first level to be the reference (0), you would see 3 parameters in the model with 3 estimates corresponding to the increase in log-odds attributable to contrasting the second, third or fourth level to the baseline.
 
 ```{r}
-
 contr.treatment(2)
 contr.treatment(4)
 ```
@@ -77,7 +76,7 @@ Below we apply `contr.treatment` to our trt01pn and sex variables. Note: how the
 lung$trt01pn <- as.factor(lung$trt01pn)
 lung$sex <- as.factor(lung$sex)
 
-m1 <- glm(
+m1 <- stats::glm(
   wt_catn ~ trt01pn + age + sex + ph.ecog + meal.cal,
   data = lung,
   family = binomial(link = "logit"),
@@ -102,7 +101,7 @@ The model summary contains the parameter estimates $\beta_j$ for each explanator
 
 ```{r}
 
-ma <- glm(
+ma <- stats::glm(
   wt_catn ~ trt01pn + age + sex + ph.ecog + meal.cal,
   data = lung,
   family = binomial(link = "logit"),
@@ -111,7 +110,7 @@ ma <- glm(
 summary(ma)
 contr.treatment(2)
 
-mb <- glm(
+mb <- stats::glm(
   wt_catn ~ trt01pn + age + sex + ph.ecog + meal.cal,
   data = lung,
   family = binomial(link = "logit"),
@@ -130,11 +129,11 @@ Using the above model, you can output the estimates and confidence intervals usi
 # model coefficients summary
 summary(m1)$coefficients
 
-## Wald confidence limits
+# Wald confidence limits
 cbind(est = exp(coef(m1)), exp(confint.default(m1)))
-## profile-likelihood limits
-cbind(est = exp(coef(m1)), exp(confint(m1)))
 
+# profile-likelihood limits
+cbind(est = exp(coef(m1)), exp(confint(m1)))
 ```
 
 # Comparing 2 models
@@ -142,7 +141,7 @@ cbind(est = exp(coef(m1)), exp(confint(m1)))
 To compare two logistic models, the `residual deviances` (-2 \* log likelihoods) are compared against a $\chi^2$-distribution with degrees of freedom calculated using the difference in the two models' parameters. Below, the only difference is the inclusion/exclusion of age in the model, hence we test using $\chi^2$ with 1 df. Here testing at the 5% level.
 
 ```{r}
-m2 <- glm(
+m2 <- stats::glm(
   wt_catn ~ trt01pn + sex + ph.ecog + meal.cal,
   data = lung,
   family = binomial(link = "logit"),
@@ -184,7 +183,7 @@ NOTE as per the output, these are on the logit scale, you need to exponentiate t
 The treatment comparison can also be output on the log-odds or back transformed scale as shown below.
 
 ```{r}
-m3 <- glm(
+m3 <- stats::glm(
   wt_catn ~ trt01pn + age + sex + ph.ecog + meal.cal,
   data = lung,
   family = binomial(link = "logit"),
@@ -193,10 +192,10 @@ m3 <- glm(
 summary(m3)
 contr.treatment(2)
 
-#log-odds for each treatment
-lsm <- emmeans(m3, "trt01pn")
+# log-odds for each treatment
+lsm <- emmeans::emmeans(m3, "trt01pn")
 lsm
-#log-odds ratios (treatment comparison): This does all pairwise comparisons
+# log-odds ratios (treatment comparison): This does all pairwise comparisons
 # However as seen below, this is TRT 1 - TRT 2
 pairs(lsm)
 
@@ -210,7 +209,6 @@ coef(pairs(lsm))
 trtdiff <- contrast(lsm, "poly")
 trtdiff
 confint(trtdiff, type = "response")
-
 ```
 
 In Summary: Treatment 2 is on average 1.48 times as likely to have weight gain compared to treatment 1, however this is not statistically significant (95% Confidence interval = 0.703-3.100, p-value= 0.3039).
@@ -226,14 +224,15 @@ We have a 3 level treatment variable (dose_id), where 1=10mg, 2=20mg doses for a
 lung2 <- lung |>
   mutate(dose_id2 = as.factor(lung$dose_id))
 
-m3 <- glm(
+m3 <- stats::glm(
   wt_catn ~ dose_id2 + age + sex + ph.ecog + meal.cal,
   data = lung2,
   family = binomial(link = "logit"),
   contrasts = list(dose_id2 = "contr.treatment")
 )
-#log-odds for each treatment
-lsm3 <- emmeans(m3, "dose_id2")
+
+# log-odds for each treatment
+lsm3 <- emmeans::emmeans(m3, "dose_id2")
 lsm3
 contrast(lsm3, list(AveDose_vs_pbo = c(0.5, 0.5, -1)))
 confint(contrast(lsm3, list(AveDose_vs_pbo = c(0.5, 0.5, -1))))
@@ -252,24 +251,22 @@ See the emmeans vignette on creating bespoke contrasts [here](Comparisons%20and%
 lung2 <- lung |>
   mutate(dose_id2 = as.factor(lung$dose_id))
 
-m3 <- glm(
+m3 <- stats::glm(
   wt_catn ~ dose_id2 + age + sex + ph.ecog + meal.cal,
   data = lung2,
   family = binomial(link = "logit"),
   contrasts = list(dose_id2 = "contr.treatment")
 )
 
-fit.contrast(m3, 'dose_id2', c(0.5, 0.5, -1), conf.int = 0.95)
+gmodels::fit.contrast(m3, 'dose_id2', c(0.5, 0.5, -1), conf.int = 0.95)
 ```
 
 # Reference
 
 ```{r}
-#\| echo: false
+#| echo: false
 
-#List all the packages needed
-
+# List all the packages needed
 si <- sessioninfo::session_info(c('dplyr', 'emmeans', 'gmodels'))
 si
-
 ```

--- a/R/logistic_regr.qmd
+++ b/R/logistic_regr.qmd
@@ -3,9 +3,9 @@ title: "Logistic Regression in R"
 ---
 
 ```{r}
-#| echo: FALSE
-#| include: FALSE
-library(dplyr)
+#| echo: false
+#| include: false
+#| library(dplyr)
 library(gmodels)
 library(emmeans)
 ```
@@ -37,12 +37,14 @@ Below we are using wt_catn (0,1) and trt01pn (1,2) and sex (1,2). Let's see what
 head(lung)
 
 ```{r}
-lung<-read.csv("../data/lung_cancer.csv")
+lung <- read.csv("../data/lung_cancer.csv")
 head(lung)
 
-m1 <- glm(wt_catn ~ trt01pn + age + sex + ph.ecog + meal.cal, 
-          data = lung, 
-          family = binomial(link="logit"))
+m1 <- glm(
+  wt_catn ~ trt01pn + age + sex + ph.ecog + meal.cal,
+  data = lung,
+  family = binomial(link = "logit")
+)
 summary(m1)
 ```
 
@@ -70,15 +72,17 @@ Below we apply `contr.treatment` to our trt01pn and sex variables. Note: how the
 
 ```{r}
 
-# Good practice to have binary variables (eg. treatment) identified as a factor 
+# Good practice to have binary variables (eg. treatment) identified as a factor
 # And to specify what contrast option you are using ! more on this below
-lung$trt01pn<-as.factor(lung$trt01pn)
-lung$sex<-as.factor(lung$sex)
+lung$trt01pn <- as.factor(lung$trt01pn)
+lung$sex <- as.factor(lung$sex)
 
-m1 <- glm(wt_catn ~ trt01pn + age + sex + ph.ecog + meal.cal, 
-          data = lung, 
-          family = binomial(link="logit"),
-          contrasts = list(trt01pn = "contr.treatment", sex = "contr.treatment"))
+m1 <- glm(
+  wt_catn ~ trt01pn + age + sex + ph.ecog + meal.cal,
+  data = lung,
+  family = binomial(link = "logit"),
+  contrasts = list(trt01pn = "contr.treatment", sex = "contr.treatment")
+)
 summary(m1)
 ```
 
@@ -98,17 +102,21 @@ The model summary contains the parameter estimates $\beta_j$ for each explanator
 
 ```{r}
 
-ma <- glm(wt_catn ~ trt01pn + age + sex + ph.ecog + meal.cal, 
-          data = lung, 
-          family = binomial(link="logit"),
-          contrasts = list(trt01pn = "contr.treatment", sex = "contr.treatment"))
+ma <- glm(
+  wt_catn ~ trt01pn + age + sex + ph.ecog + meal.cal,
+  data = lung,
+  family = binomial(link = "logit"),
+  contrasts = list(trt01pn = "contr.treatment", sex = "contr.treatment")
+)
 summary(ma)
 contr.treatment(2)
 
-mb <- glm(wt_catn ~ trt01pn + age + sex + ph.ecog + meal.cal, 
-          data = lung, 
-          family = binomial(link="logit"),
-          contrasts = list(trt01pn = "contr.sum", sex = "contr.treatment"))
+mb <- glm(
+  wt_catn ~ trt01pn + age + sex + ph.ecog + meal.cal,
+  data = lung,
+  family = binomial(link = "logit"),
+  contrasts = list(trt01pn = "contr.sum", sex = "contr.treatment")
+)
 summary(mb)
 contr.sum(2)
 
@@ -123,12 +131,9 @@ Using the above model, you can output the estimates and confidence intervals usi
 summary(m1)$coefficients
 
 ## Wald confidence limits
-cbind(est = exp(coef(m1)), 
-          exp(confint.default(m1)))
+cbind(est = exp(coef(m1)), exp(confint.default(m1)))
 ## profile-likelihood limits
-cbind(est = exp(coef(m1)), 
-          exp(confint(m1)))
-
+cbind(est = exp(coef(m1)), exp(confint(m1)))
 
 ```
 
@@ -137,10 +142,12 @@ cbind(est = exp(coef(m1)),
 To compare two logistic models, the `residual deviances` (-2 \* log likelihoods) are compared against a $\chi^2$-distribution with degrees of freedom calculated using the difference in the two models' parameters. Below, the only difference is the inclusion/exclusion of age in the model, hence we test using $\chi^2$ with 1 df. Here testing at the 5% level.
 
 ```{r}
-m2 <- glm(wt_catn ~ trt01pn + sex + ph.ecog + meal.cal, 
-                    data = lung, 
-                    family = binomial(link="logit"),
-                    contrasts = list(trt01pn = "contr.treatment"))
+m2 <- glm(
+  wt_catn ~ trt01pn + sex + ph.ecog + meal.cal,
+  data = lung,
+  family = binomial(link = "logit"),
+  contrasts = list(trt01pn = "contr.treatment")
+)
 summary(m2)
 
 anova(m1, m2, test = "LRT")
@@ -154,9 +161,15 @@ Predictions from the model for the log-odds of a patient with new data to experi
 
 ```{r}
 # new female, symptomatic but completely ambulatory patient consuming 2500 calories
-new_pt <- data.frame(trt01pn=1, age=48, sex=2, ph.ecog=1, meal.cal=2500)
-new_pt$trt01pn<-as.factor(new_pt$trt01pn)
-new_pt$sex<-as.factor(new_pt$sex)
+new_pt <- data.frame(
+  trt01pn = 1,
+  age = 48,
+  sex = 2,
+  ph.ecog = 1,
+  meal.cal = 2500
+)
+new_pt$trt01pn <- as.factor(new_pt$trt01pn)
+new_pt$sex <- as.factor(new_pt$sex)
 predict(m1, new_pt, type = "response")
 ```
 
@@ -171,30 +184,32 @@ NOTE as per the output, these are on the logit scale, you need to exponentiate t
 The treatment comparison can also be output on the log-odds or back transformed scale as shown below.
 
 ```{r}
-m3 <- glm(wt_catn ~ trt01pn + age + sex + ph.ecog + meal.cal, 
-          data = lung, 
-          family = binomial(link="logit"),
-          contrasts = list(trt01pn = "contr.treatment"))
+m3 <- glm(
+  wt_catn ~ trt01pn + age + sex + ph.ecog + meal.cal,
+  data = lung,
+  family = binomial(link = "logit"),
+  contrasts = list(trt01pn = "contr.treatment")
+)
 summary(m3)
 contr.treatment(2)
 
 #log-odds for each treatment
-lsm<-emmeans(m3,"trt01pn")
+lsm <- emmeans(m3, "trt01pn")
 lsm
 #log-odds ratios (treatment comparison): This does all pairwise comparisons
 # However as seen below, this is TRT 1 - TRT 2
 pairs(lsm)
 
 # the below creates tests and CI's prior to back transformation (ratios of geometric means)
-pairs(lsm, type="response")
+pairs(lsm, type = "response")
 
 # see coefficients of the linear functions
 coef(pairs(lsm))
 
 # Output treatment contrasts 2 vs 1 and 95% CIs, the type="response" option back transforms the results
-trtdiff<-contrast(lsm,"poly")
+trtdiff <- contrast(lsm, "poly")
 trtdiff
-confint(trtdiff, type="response")
+confint(trtdiff, type = "response")
 
 ```
 
@@ -208,18 +223,20 @@ We have a 3 level treatment variable (dose_id), where 1=10mg, 2=20mg doses for a
 
 ```{r}
 
-lung2<-lung |> 
-    mutate(dose_id2 = as.factor(lung$dose_id))
+lung2 <- lung |>
+  mutate(dose_id2 = as.factor(lung$dose_id))
 
-m3 <- glm (wt_catn ~ dose_id2 + age + sex + ph.ecog + meal.cal, 
-                     data = lung2, 
-                     family = binomial(link="logit"),
-                     contrasts = list(dose_id2 = "contr.treatment"))
+m3 <- glm(
+  wt_catn ~ dose_id2 + age + sex + ph.ecog + meal.cal,
+  data = lung2,
+  family = binomial(link = "logit"),
+  contrasts = list(dose_id2 = "contr.treatment")
+)
 #log-odds for each treatment
-lsm3<-emmeans(m3,"dose_id2")
+lsm3 <- emmeans(m3, "dose_id2")
 lsm3
-contrast (lsm3,list(AveDose_vs_pbo=c(0.5,0.5,-1)))
-confint(contrast (lsm3,list(AveDose_vs_pbo=c(0.5,0.5,-1))))
+contrast(lsm3, list(AveDose_vs_pbo = c(0.5, 0.5, -1)))
+confint(contrast(lsm3, list(AveDose_vs_pbo = c(0.5, 0.5, -1))))
 ```
 
 Here we found that on average there is -0.41 times the risk of weight gain on active vs placebo but that this is not statisticallly significantly different (95% CI -1.15 to 0.335, p-value = 0.2813).
@@ -232,15 +249,17 @@ See the emmeans vignette on creating bespoke contrasts [here](Comparisons%20and%
 
 ```{r}
 
-lung2<-lung |> 
-    mutate(dose_id2 = as.factor(lung$dose_id))
+lung2 <- lung |>
+  mutate(dose_id2 = as.factor(lung$dose_id))
 
-m3 <- glm (wt_catn ~ dose_id2 + age + sex + ph.ecog + meal.cal, 
-                     data = lung2, 
-                     family = binomial(link="logit"),
-                     contrasts = list(dose_id2 = "contr.treatment"))
+m3 <- glm(
+  wt_catn ~ dose_id2 + age + sex + ph.ecog + meal.cal,
+  data = lung2,
+  family = binomial(link = "logit"),
+  contrasts = list(dose_id2 = "contr.treatment")
+)
 
-fit.contrast (m3,'dose_id2',c(0.5,0.5,-1),conf.int=0.95)
+fit.contrast(m3, 'dose_id2', c(0.5, 0.5, -1), conf.int = 0.95)
 ```
 
 # Reference
@@ -250,7 +269,7 @@ fit.contrast (m3,'dose_id2',c(0.5,0.5,-1),conf.int=0.95)
 
 #List all the packages needed
 
-si <- sessioninfo::session_info(c('dplyr','emmeans','gmodels')) 
+si <- sessioninfo::session_info(c('dplyr', 'emmeans', 'gmodels'))
 si
 
 ```

--- a/R/logistic_regr.qmd
+++ b/R/logistic_regr.qmd
@@ -5,7 +5,7 @@ title: "Logistic Regression in R"
 ```{r}
 #| echo: false
 #| include: false
-#| library(dplyr)
+library(dplyr)
 library(gmodels)
 library(emmeans)
 ```

--- a/R/manova.qmd
+++ b/R/manova.qmd
@@ -29,8 +29,8 @@ We are testing H0: group mean vectors are the same for all groups or they dont d
 H1: At least one of the group mean vectors is different from the rest.
 
 ```{r}
-dep_vars <- cbind(pottery$al,pottery$fe,pottery$mg, pottery$ca, pottery$na)
-fit <-manova(dep_vars ~ pottery$site)
+dep_vars <- cbind(pottery$al, pottery$fe, pottery$mg, pottery$ca, pottery$na)
+fit <- manova(dep_vars ~ pottery$site)
 summary.aov(fit)
 
 ```
@@ -48,10 +48,18 @@ summary(fit)
 NOTE: interest may now lie in using pre-planned contrast statements to investigate if one site differs when compared to the average of the others. You would imagine this could be done using the 'contrast' function something like the code below, however this result does not match the SAS user guide and so looks to be doing a different analysis. **SUGGEST THIS IS NOT USED UNTIL MORE RESEARCH INTO THIS METHOD CAN BE PERFORMED.** One alternative suggestion is to perform a linear descriminent analysis (LDA).
 
 ```{r}
-manova(dep_vars ~ pottery$site) %>% 
-          emmeans("site") %>% 
-     contrast(method=list(
-          "Llanederyn vs other sites"= c("Llanederyn"=-3, "Caldicot"=1, "IslandThorns"=1, "AshleyRails"=1)))
+manova(dep_vars ~ pottery$site) |>
+  emmeans("site") |>
+  contrast(
+    method = list(
+      "Llanederyn vs other sites" = c(
+        "Llanederyn" = -3,
+        "Caldicot" = 1,
+        "IslandThorns" = 1,
+        "AshleyRails" = 1
+      )
+    )
+  )
 
 ```
 

--- a/R/manova.qmd
+++ b/R/manova.qmd
@@ -30,9 +30,8 @@ H1: At least one of the group mean vectors is different from the rest.
 
 ```{r}
 dep_vars <- cbind(pottery$al, pottery$fe, pottery$mg, pottery$ca, pottery$na)
-fit <- manova(dep_vars ~ pottery$site)
-summary.aov(fit)
-
+fit <- stats::manova(dep_vars ~ pottery$site)
+stats::summary.aov(fit)
 ```
 
 'summary(fit)' outputs the MANOVA testing of an overall site effect.
@@ -49,7 +48,7 @@ NOTE: interest may now lie in using pre-planned contrast statements to investiga
 
 ```{r}
 manova(dep_vars ~ pottery$site) |>
-  emmeans("site") |>
+  emmeans::emmeans("site") |>
   contrast(
     method = list(
       "Llanederyn vs other sites" = c(

--- a/R/marginal_homogeneity_tests.qmd
+++ b/R/marginal_homogeneity_tests.qmd
@@ -34,35 +34,38 @@ cases <- c(4, 2, 3, 1, 59)
 n <- sum(cases)
 cochran <- data.frame(
   diphtheria = factor(
-    unlist(rep(list(c(1, 1, 1, 1),
-                    c(1, 1, 0, 1),
-                    c(0, 1, 1, 1),
-                    c(0, 1, 0, 1),
-                    c(0, 0, 0, 0)),
-                cases)
-    )
+    unlist(rep(
+      list(
+        c(1, 1, 1, 1),
+        c(1, 1, 0, 1),
+        c(0, 1, 1, 1),
+        c(0, 1, 0, 1),
+        c(0, 0, 0, 0)
+      ),
+      cases
+    ))
   ),
   media = factor(rep(LETTERS[1:4], n)),
-  case =  factor(rep(seq_len(n), each = 4))
+  case = factor(rep(seq_len(n), each = 4))
 )
 
 head(cochran)
 
 ## Asymptotic Cochran Q test (Cochran, 1950, p. 260)
 coin::mh_test(
-  diphtheria ~ media | case, 
+  diphtheria ~ media | case,
   data = cochran
-) 
+)
 
 ## Approximative Cochran Q test
 mt <- coin::mh_test(
-  diphtheria ~ media | case, 
+  diphtheria ~ media | case,
   data = cochran,
   distribution = coin::approximate(nresample = 10000)
 )
-coin::pvalue(mt)             # standard p-value
-coin::midpvalue(mt)          # mid-p-value
-coin::pvalue_interval(mt)    # p-value interval
+coin::pvalue(mt) # standard p-value
+coin::midpvalue(mt) # mid-p-value
+coin::pvalue_interval(mt) # p-value interval
 coin::size(mt, alpha = 0.05) # test size at alpha = 0.05 using the p-value
 ```
 
@@ -71,8 +74,13 @@ coin::size(mt, alpha = 0.05) # test size at alpha = 0.05 using the p-value
 ```{r}
 ## Opinions on Pre- and Extramarital Sex
 ## Agresti (2002, p. 421)
-opinions <- c("Always wrong", "Almost always wrong",
-              "Wrong only sometimes", "Not wrong at all")
+opinions <- c(
+  "Always wrong",
+  "Almost always wrong",
+  "Wrong only sometimes",
+  "Not wrong at all"
+)
+# fmt: skip
 PreExSex <- matrix(
   c(144, 33, 84, 126,
     2,  4, 14,  29,
@@ -94,7 +102,7 @@ coin::mh_test(PreExSex)
 ## Asymptotic Stuart-Birch test
 ## Note: response as ordinal
 coin::mh_test(
-  PreExSex, 
+  PreExSex,
   scores = list(response = 1:length(opinions))
 )
 ```
@@ -104,6 +112,7 @@ coin::mh_test(
 ```{r}
 ## Vote intention
 ## Madansky (1963, pp. 107-108)
+# fmt: skip
 vote <- array(
     c(120, 1,  8, 2,   2,  1, 2, 1,  7,
         6, 2,  1, 1, 103,  5, 1, 4,  8,
@@ -124,6 +133,7 @@ coin::mh_test(vote)
 
 ## Cross-over study
 ## http://www.nesug.org/proceedings/nesug00/st/st9005.pdf (link is dead now)
+# fmt: skip
 dysmenorrhea <- array(
   c(6, 2, 1,  3, 1, 0,  1, 2, 1,
     4, 3, 0, 13, 3, 0,  8, 1, 1,
@@ -142,14 +152,14 @@ dysmenorrhea
 ## Asymptotic Madansky-Birch test (Q = 53.76)
 ## Note: response as ordinal
 coin::mh_test(
-  dysmenorrhea, 
+  dysmenorrhea,
   scores = list(response = 1:3)
 )
 
 ## Asymptotic Madansky-Birch test (Q = 47.29)
 ## Note: response and measurement conditions as ordinal
 coin::mh_test(
-  dysmenorrhea, 
+  dysmenorrhea,
   scores = list(response = 1:3, conditions = 1:3)
 )
 ```
@@ -178,10 +188,11 @@ White, A. A., Landis, J. R. and Cooper, M. M. (1982). A note on the equivalence 
 ```{r}
 #| echo: false
 
-# List all the packages needed 
+# List all the packages needed
 si <- sessioninfo::session_info(c(
   "coin"
 ))
 si
 ```
+
 :::

--- a/R/mcnemar.qmd
+++ b/R/mcnemar.qmd
@@ -12,9 +12,7 @@ To demonstrate McNemar's test, data was used concerning the presence or absence 
 #| echo: false
 #| include: false
 
-colds <- 
-  read.csv(
-    file = "../data/colds.csv")
+colds <- read.csv(file = "../data/colds.csv")
 freq_tbl <- table("age12" = colds$age12, "age14" = colds$age14)
 freq_tbl
 ```
@@ -26,11 +24,13 @@ McNemar's test can also be performed using `stats::mcnemar.test` as shown below,
 ```{r}
 mcnemar.test(freq_tbl)
 ```
+
 The other possible input to `mcnemar.test` is `correct =` which is a true/false value to indicate if the continuity correction should be applied. To get the result without continuity correction by specify `correct=FALSE`.
 
 ```{r}
-mcnemar.test(freq_tbl, correct=FALSE)
+mcnemar.test(freq_tbl, correct = FALSE)
 ```
+
 ## Example Code using {coin}
 
 McNemar test is calculated [without continuity correction]{.underline} which corresponds to SAS FREQ procedure (see [R v SAS McNemar’s test](https://psiaims.github.io/CAMIS/Comp/r-sas_mcnemar.html) for more details).
@@ -42,7 +42,7 @@ coin::mh_test(freq_tbl)
 
 ## Approximative McNemar Test
 coin::mh_test(
-  freq_tbl, 
+  freq_tbl,
   distribution = coin::approximate(nresample = 10000)
 )
 
@@ -50,7 +50,9 @@ coin::mh_test(
 coin::mh_test(freq_tbl, distribution = "exact")
 
 ```
+
 #### Calculating Confidence Intervals with {vcd}
+
 It is common when calculating McNemar, to also want to check the level agreement between the two rates. To do this we use Cohen's Kappa and its associated confidence intervals. To do this, we use the `vcd` package as follows: 
 
 ```{r}
@@ -58,11 +60,7 @@ library(vcd)
 cohen_kappa <- Kappa(freq_tbl)
 cohen_kappa
 confint(cohen_kappa, level = 0.95)
-
-
 ```
-
-
 
 #### Using the `epibasix::mcnemar` function
 

--- a/R/mcnemar.qmd
+++ b/R/mcnemar.qmd
@@ -22,13 +22,13 @@ freq_tbl
 McNemar's test can also be performed using `stats::mcnemar.test` as shown below, using the same table `X` as in the previous section.
 
 ```{r}
-mcnemar.test(freq_tbl)
+stats::mcnemar.test(freq_tbl)
 ```
 
 The other possible input to `mcnemar.test` is `correct =` which is a true/false value to indicate if the continuity correction should be applied. To get the result without continuity correction by specify `correct=FALSE`.
 
 ```{r}
-mcnemar.test(freq_tbl, correct = FALSE)
+stats::mcnemar.test(freq_tbl, correct = FALSE)
 ```
 
 ## Example Code using {coin}
@@ -57,7 +57,7 @@ It is common when calculating McNemar, to also want to check the level agreement
 
 ```{r}
 library(vcd)
-cohen_kappa <- Kappa(freq_tbl)
+cohen_kappa <- vcd::Kappa(freq_tbl)
 cohen_kappa
 confint(cohen_kappa, level = 0.95)
 ```

--- a/R/mi_mar_predictive_mean_match.qmd
+++ b/R/mi_mar_predictive_mean_match.qmd
@@ -45,7 +45,8 @@ To impute with PMM is straightforward: specify the method, `method = pmm`.
 #| label: impute-pmm
 #| echo: true
 #| eval: true
-imp_pmm <- mice(nhanes, method = 'pmm', m = 5, maxit = 10)
+
+imp_pmm <- mice::mice(nhanes, method = 'pmm', m = 5, maxit = 10)
 imp_pmm
 
 # imputations for bmi
@@ -59,7 +60,7 @@ An alternative to the standard PMM is `midastouch`.
 #| echo: true
 #| eval: true
 
-imp_pmms <- mice(nhanes, method = 'midastouch', m = 5, maxit = 10)
+imp_pmms <- mice::mice(nhanes, method = 'midastouch', m = 5, maxit = 10)
 imp_pmm
 
 imp_pmms$imp$bmi

--- a/R/mi_mar_predictive_mean_match.qmd
+++ b/R/mi_mar_predictive_mean_match.qmd
@@ -19,9 +19,6 @@ Implementation of PMM in `mice`:
 * Weighted predictive mean matching, [mice.impute.midastouch](https://amices.org/mice/reference/mice.impute.midastouch.html)
 * Multivariate predictive mean matching, [mice.impute.mpmm](https://amices.org/mice/reference/mice.impute.mpmm.html)
 
-
-
-
 ## Example
 
 We use the small dataset `nhanes` included in `mice` package. It has 25 rows, and three out of four variables have missings. 
@@ -48,13 +45,12 @@ To impute with PMM is straightforward: specify the method, `method = pmm`.
 #| label: impute-pmm
 #| echo: true
 #| eval: true
-imp_pmm <- mice(nhanes, method = 'pmm', m=5, maxit=10)
+imp_pmm <- mice(nhanes, method = 'pmm', m = 5, maxit = 10)
 imp_pmm
 
 # imputations for bmi
 imp_pmm$imp$bmi
 ```
-
 
 An alternative to the standard PMM is `midastouch`.
 
@@ -63,16 +59,12 @@ An alternative to the standard PMM is `midastouch`.
 #| echo: true
 #| eval: true
 
-imp_pmms <- mice(nhanes, method = 'midastouch', m=5, maxit=10)
+imp_pmms <- mice(nhanes, method = 'midastouch', m = 5, maxit = 10)
 imp_pmm
 
 imp_pmms$imp$bmi
 ```
 
-
-
-
 # Reference
 
 Stef van Buuren, Karin Groothuis-Oudshoorn (2011). mice: Multivariate Imputation by Chained Equations in R. Journal of Statistical Software, 45(3), 1-67. DOI 10.18637/jss.v045.i03
-

--- a/R/mi_mar_regression.qmd
+++ b/R/mi_mar_regression.qmd
@@ -6,7 +6,6 @@ title: "Multiple Imputaton: Linear Regression"
 
 Multiple imputation with regression is one step further from mean imputation (i.e. by a single value: the average of observed). In the case for continuous, normally distributed variable, linear regression can use information from other variables hence *could* be closer to the true missing values.
 
-
 ## Imputation with `mice`
 
 [mice](https://amices.org/mice/index.html) is a powerful R package developed by Stef van Buuren, Karin Groothuis-Oudshoorn and other contributors. **Regression methods** (continuous, normal outcome) are implemented in `mice` with methods starting with `norm`.
@@ -146,12 +145,6 @@ impbt <- mice(nhanes, method = 'norm.boot', m=1, maxit=1)
 impbt$imp$bmi
 ```
 
-
-
-
-
-
 # Reference
 
 Stef van Buuren, Karin Groothuis-Oudshoorn (2011). mice: Multivariate Imputation by Chained Equations in R. Journal of Statistical Software, 45(3), 1-67. DOI 10.18637/jss.v045.i03
-

--- a/R/mi_mar_regression.qmd
+++ b/R/mi_mar_regression.qmd
@@ -47,7 +47,7 @@ Examine missing pattern with `md.pattern(data)`.
 # by col: 8 for hyp, 9 for bmi, 10 for chl
 # by row: n missing numbers
 
-md.pattern(nhanes)
+mice::md.pattern(nhanes)
 ```
 
 
@@ -63,12 +63,13 @@ There is a certain level of randomness, so would be a good idea to set seed.
 #| eval: true
 
 set.seed(1)
-impr0 <- mice(nhanes, method = 'norm.nob', m=2, maxit = 1)
+impr0 <- mice::mice(nhanes, method = 'norm.nob', m = 2, maxit = 1)
 impr0
 
-nhanes_impr0 <- complete(impr0) # by default, returns the first imputation
+nhanes_impr0 <- mice::complete(impr0) # by default, returns the first imputation
 nhanes_impr0
 ```
+
 When we have two imputed datasets, we can check the values for each of the variables. For example, extract `bmi` variable from the imputed data `imp`,
 
 ```{r}
@@ -96,13 +97,13 @@ Here we check which of the imputed data is being used as the completed dataset. 
 id_missing <- which(is.na(nhanes$bmi))
 id_missing
 
-nhanes_impr0_action0 <- complete(impr0, action = 0) 
+nhanes_impr0_action0 <- mice::complete(impr0, action = 0)
 nhanes_impr0_action0[id_missing, ] # original data with missing bmi
 
-nhanes_impr0_action1 <- complete(impr0, action = 1) 
+nhanes_impr0_action1 <- mice::complete(impr0, action = 1)
 nhanes_impr0_action1[id_missing, ] # using first imputation
 
-nhanes_impr0_action2 <- complete(impr0, action = 2) 
+nhanes_impr0_action2 <- mice::complete(impr0, action = 2)
 nhanes_impr0_action2[id_missing, ] # using second imputation
 ```
 
@@ -119,7 +120,8 @@ Other various of imputaton via linear regression can be implemented simply by ch
 #| label: impute-reg-pred
 #| echo: true
 #| eval: true
-impr <- mice(nhanes, method = 'norm.predict', m=1, maxit=1)
+
+impr <- mice::mice(nhanes, method = 'norm.predict', m = 1, maxit = 1)
 impr$imp$bmi
 ```
 
@@ -129,7 +131,7 @@ Bayesian linear regression
 #| label: impute-reg-bayes
 #| echo: true
 #| eval: true
-impb <- mice(nhanes, method = 'norm', m=1, maxit=1)
+impb <- mice(nhanes, method = 'norm', m = 1, maxit = 1)
 impb$imp$bmi
 # nhanes_impb <- complete(impb)
 ```
@@ -141,7 +143,7 @@ Bootstrap
 #| echo: true
 #| eval: true
 
-impbt <- mice(nhanes, method = 'norm.boot', m=1, maxit=1)
+impbt <- mice(nhanes, method = 'norm.boot', m = 1, maxit = 1)
 impbt$imp$bmi
 ```
 

--- a/R/mmrm.qmd
+++ b/R/mmrm.qmd
@@ -4,22 +4,11 @@ title: "MMRM in R"
 
 ## Fitting the MMRM in R
 
-Mixed models for repeated measures (MMRM) are a popular
-choice for analyzing longitudinal continuous outcomes in randomized
-clinical trials and beyond; see
-[Cnaan, Laird and Slasor (1997)](https://doi.org/10.1002/(SICI)1097-0258(19971030)16:20<2349::AID-SIM667>3.0.CO;2-E)
-for a tutorial and
-[Mallinckrodt, Lane and Schnell (2008)](https://doi.org/10.1177/009286150804200402)
-for a review. 
+Mixed models for repeated measures (MMRM) are a popular choice for analyzing longitudinal continuous outcomes in randomized clinical trials and beyond; see [Cnaan, Laird and Slasor (1997)](https://doi.org/10.1002/(SICI)1097-0258(19971030)16:20<2349::AID-SIM667>3.0.CO;2-E) for a tutorial and [Mallinckrodt, Lane and Schnell (2008)](https://doi.org/10.1177/009286150804200402) for a review. 
 
 This vignette shows examples from the `mmrm` package.
 
-The `mmrm` package implements MMRM based on the marginal linear model without 
-random effects using Template Model Builder (`TMB`) which enables fast and 
-robust model fitting. Users can specify a variety of covariance matrices, weight
-observations, fit models with restricted or standard maximum
-likelihood inference, perform hypothesis testing with Satterthwaite
-or Kenward-Roger adjustment, and extract least
+The `mmrm` package implements MMRM based on the marginal linear model without  random effects using Template Model Builder (`TMB`) which enables fast and  robust model fitting. Users can specify a variety of covariance matrices, weight observations, fit models with restricted or standard maximum likelihood inference, perform hypothesis testing with Satterthwaite or Kenward-Roger adjustment, and extract least
 square means estimates by using `emmeans`.
 
 ### Main Features
@@ -66,25 +55,16 @@ fit <- mmrm(
 )
 ```
 
-The code specifies an MMRM with the given covariates and an unstructured covariance
-matrix for the timepoints (also called visits in the clinical trial context, here
-given by `AVISIT`) within the subjects (here `USUBJID`). While by default this uses
-restricted maximum likelihood (REML), it is also possible to use ML, see `?mmrm`.
+The code specifies an MMRM with the given covariates and an unstructured covariance matrix for the timepoints (also called visits in the clinical trial context, here given by `AVISIT`) within the subjects (here `USUBJID`). While by default this uses restricted maximum likelihood (REML), it is also possible to use ML, see `?mmrm`.
 
-Printing the object will show you output which should be familiar to anyone who
-has used any popular modeling functions such as `stats::lm()`, `stats::glm()`,
-`glmmTMB::glmmTMB()`, and `lme4::nlmer()`. From this print out we see the function call,
-the data used, the covariance structure with number of variance parameters, as well
-as the likelihood method, and model deviance achieved. Additionally the user is
-provided a printout of the estimated coefficients and the model convergence information:
+Printing the object will show you output which should be familiar to anyone who has used any popular modeling functions such as `stats::lm()`, `stats::glm()`, `glmmTMB::glmmTMB()`, and `lme4::nlmer()`. From this print out we see the function call, the data used, the covariance structure with number of variance parameters, as well as the likelihood method, and model deviance achieved. Additionally the user is provided a printout of the estimated coefficients and the model convergence information:
 
 ```{r}
 #| label: print
 fit
 ```
 
-The `summary()` method then provides the coefficients table with Satterthwaite
-degrees of freedom as well as the covariance matrix estimate:
+The `summary()` method then provides the coefficients table with Satterthwaite degrees of freedom as well as the covariance matrix estimate:
 
 ```{r}
 #| label: summary
@@ -92,13 +72,9 @@ fit |>
   summary()
 ```
 
-
 ### Extracting effect estimates using `emmeans`
 
-In order to extract relevant marginal means (LSmeans) and contrasts we can use the `emmeans` package. 
-This package includes methods that allow `mmrm` objects to be used with the
-`emmeans` package. `emmeans` computes estimated marginal means (also called
-least-square means) for the coefficients of the MMRM.
+In order to extract relevant marginal means (LSmeans) and contrasts we can use the `emmeans` package. This package includes methods that allow `mmrm` objects to be used with the `emmeans` package. `emmeans` computes estimated marginal means (also called least-square means) for the coefficients of the MMRM.
 
 ```{r}
 #| label: emmeans

--- a/R/mmrm.qmd
+++ b/R/mmrm.qmd
@@ -49,7 +49,7 @@ The code below implements an MMRM fit in R with the `mmrm::mmrm` function.
 
 ```{r}
 library(mmrm)
-fit <- mmrm(
+fit <- mmrm::mmrm(
   formula = FEV1 ~ RACE + SEX + ARMCD * AVISIT + us(AVISIT | USUBJID),
   data = fev_data
 )
@@ -78,9 +78,9 @@ In order to extract relevant marginal means (LSmeans) and contrasts we can use t
 
 ```{r}
 #| label: emmeans
-if (require(emmeans)) {
-  emmeans(fit, ~ ARMCD | AVISIT)
-}
+library(emmeans)
+
+emmeans(fit, ~ ARMCD | AVISIT)
 ```
 
 Note that the degrees of freedom choice is inherited here from the initial `mmrm`

--- a/R/nonpara_wilcoxon_ranksum.qmd
+++ b/R/nonpara_wilcoxon_ranksum.qmd
@@ -190,13 +190,18 @@ The `asht::wmwTest()` function calculates the Wilcoxon-Mann-Whitney test (normal
 By default, the function returns the normal approximation using a continuity correction. The `correct` argument is available to turn-off the continuity correction. The `alternative` argument is available for one-sided testing. By default, the 95% confidence interval is calculated for the Mann-Whitney parameter (use argument `conf.int` and `conf.level` to change these defaults.). Details on the calculation of the confidence interval are provided in Newcombe (2006) \[Newcombe, Robert G. (2006). Confidence intervals for an effect size measure based on the Mann-Whitney statistic. Part 2: asymptotic methods and evaluation. Statistics in medicine 25(4): 559-573\].
 
 ```{r}
-wmwTest(bw_s, bw_ns)
+asht::wmwTest(bw_s, bw_ns)
 ```
 
 Using the `method` argument one can change from normal approximation to exact complete enumeration (`method = "exact.ce"`), and exact Monte Carlo (`method = "exact.mc"`) implementation. When `method = "exact.mc"`, the test is implemented using complete enumeration of all permutations, and hence is only tractible for very small sample sizes (less than 10 in each group). Here, we show an example of `method = "exact.mc"`.
 
 ```{r}
-wmwTest(bw_s, bw_ns, method = "exact.mc", control = wmwControl(nMC = 100000))
+asht::wmwTest(
+  bw_s,
+  bw_ns,
+  method = "exact.mc",
+  control = asht::wmwControl(nMC = 100000)
+)
 ```
 
 

--- a/R/nonpara_wilcoxon_ranksum.qmd
+++ b/R/nonpara_wilcoxon_ranksum.qmd
@@ -3,8 +3,8 @@ title: "Wilcoxon Rank Sum (Mann Whitney-U) in R"
 ---
 
 ```{r}
-#| echo: FALSE
-#| include: FALSE
+#| echo: false
+#| include: false
 library(tidyverse)
 library(coin)
 library(asht)
@@ -50,12 +50,14 @@ Comparison of birth weights (kg) of children born to 15 non-smokers with those o
 #| echo: true
 # bw_ns: non smokers
 # bw_s: smokers
+# fmt: skip
 bw_ns <- c(3.99, 3.89, 3.6, 3.73, 3.31, 
             3.7, 4.08, 3.61, 3.83, 3.41, 
             4.13, 3.36, 3.54, 3.51, 2.71)
+# fmt: skip
 bw_s <- c(3.18, 2.74, 2.9, 3.27, 3.65, 
-           3.42, 3.23, 2.86, 3.6, 3.65, 
-           3.69, 3.53, 2.38, 2.34)
+          3.42, 3.23, 2.86, 3.6, 3.65, 
+          3.69, 3.53, 2.38, 2.34)
 ```
 
 We do note that there are ties present in the data. Can visualize the data on two histograms. Red lines indicate the location of medians.
@@ -63,7 +65,7 @@ We do note that there are ties present in the data. Can visualize the data on tw
 ```{r}
 #| eval: true
 #| echo: true
-par(mfrow =c(1,2))
+par(mfrow = c(1, 2))
 hist(bw_ns, main = 'Birthweight: non-smokers')
 abline(v = median(bw_ns), col = 'red', lwd = 2)
 hist(bw_s, main = 'Birthweight: smokers')
@@ -124,9 +126,9 @@ In order to account for the ties, `wilcox_test` from the `coin` package should b
 #| echo: true
 
 smk_data <- data.frame(
-  value = c(bw_ns, bw_s), 
+  value = c(bw_ns, bw_s),
   smoke = as.factor(rep(c("non", "smoke"), c(length(bw_ns), length(bw_s))))
-) 
+)
 smk_data$smoke <- forcats::fct_relevel(smk_data$smoke, "smoke")
 smk_data$smoke
 ```
@@ -140,30 +142,42 @@ coin::wilcox_test(value ~ smoke, data = smk_data)
 We do note that a normal approximation approach with continuity correction cannot be obtained with this function. One can add `correct=FALSE`, but note that no error is given and the results of a normal approximation approach without continuity correction is provided.
 
 ```{r}
-coin::wilcox_test(value ~ smoke, data = smk_data, correct=FALSE)
+coin::wilcox_test(value ~ smoke, data = smk_data, correct = FALSE)
 ```
 
 By including the `conf.int = TRUE` argument, confidence intervals for the difference in location are computed. According to the `coin` package documentation this is done according to Bauer (1972) \[Bauer, D. F. (1972). Constructing confidence sets using rank statistics. Journal of the American Statistical Association 67(339), 687–690\] and Hollander and Wolfe (1999) \[Hollander, M. and Wolfe, D. A. (1999). Nonparametric Statistical Methods, Second Edition. New York: John Wiley & Sons.\]. Note that the `conf.level` argument controls the confidence level, but must be used with `conf.int = TRUE` otherwise you won't get a confidence interval.
 
 ```{r}
-coin::wilcox_test(value ~ smoke, data = smk_data, conf.int  = TRUE)
+coin::wilcox_test(value ~ smoke, data = smk_data, conf.int = TRUE)
 ```
 
 Using `coin` one can calculate exact and Monte Carlo conditional p-values using the `distribtuion` argument. The exact p-value is best used in small sample sizes.
 
 ```{r}
-coin::wilcox_test(value ~ smoke, data = smk_data, conf.int  = TRUE,
-                  distribution = "exact")
+coin::wilcox_test(
+  value ~ smoke,
+  data = smk_data,
+  conf.int = TRUE,
+  distribution = "exact"
+)
 ```
 
 
 For doing an approximative (Monte Carlo) (with 500 and 500000 samples) the following code can be used.
 
 ```{r}
-coin::wilcox_test(value ~ smoke, data = smk_data, conf.int  = TRUE,
-                  distribution = approximate(nresample = 500))
-coin::wilcox_test(value ~ smoke, data = smk_data, conf.int  = TRUE,
-                  distribution = approximate(nresample = 500000))
+coin::wilcox_test(
+  value ~ smoke,
+  data = smk_data,
+  conf.int = TRUE,
+  distribution = approximate(nresample = 500)
+)
+coin::wilcox_test(
+  value ~ smoke,
+  data = smk_data,
+  conf.int = TRUE,
+  distribution = approximate(nresample = 500000)
+)
 ```
 
 <!-- *Note:* the distribution argument only effects the p-value and estimate of difference in location. In contrast, `coin` consistently calculated the exact Hodges-Lehmann confidence intervals. -->
@@ -182,8 +196,7 @@ wmwTest(bw_s, bw_ns)
 Using the `method` argument one can change from normal approximation to exact complete enumeration (`method = "exact.ce"`), and exact Monte Carlo (`method = "exact.mc"`) implementation. When `method = "exact.mc"`, the test is implemented using complete enumeration of all permutations, and hence is only tractible for very small sample sizes (less than 10 in each group). Here, we show an example of `method = "exact.mc"`.
 
 ```{r}
-wmwTest(bw_s, bw_ns,
-        method = "exact.mc", control = wmwControl(nMC = 100000))
+wmwTest(bw_s, bw_ns, method = "exact.mc", control = wmwControl(nMC = 100000))
 ```
 
 

--- a/R/nparestimate.qmd
+++ b/R/nparestimate.qmd
@@ -20,12 +20,15 @@ There are several packages covering this functionality. However, we will focus o
 
 ```{r}
 # Hollander-Wolfe-Chicken Example
+# fmt: skip
 x <- c(1.83, 0.50, 1.62, 2.48, 1.68, 1.88, 1.55, 3.06, 1.30)
+
+# fmt: skip
 y <- c(0.878, 0.647, 0.598, 2.050, 1.060, 1.290, 1.060, 3.140, 1.290)
 
 # Reshaping data
 value <- c(x, y)
-treat<- c(rep("A", length(x)), rep("B", length(y)))
+treat <- c(rep("A", length(x)), rep("B", length(y)))
 all <- data.frame(value)
 all$treat <- treat
 ```
@@ -55,7 +58,5 @@ wilcox.test(all$value ~ all$treat, exact = TRUE, conf.int = TRUE)
 ## {pairwiseCI}
 
 ```{r}
-wilcox_test(value ~ as.factor(treat), data = all, 
-           conf.int = TRUE)
-
+wilcox_test(value ~ as.factor(treat), data = all, conf.int = TRUE)
 ```

--- a/R/nparestimate.qmd
+++ b/R/nparestimate.qmd
@@ -55,8 +55,8 @@ wt$conf.int
 stats::wilcox.test(all$value ~ all$treat, exact = TRUE, conf.int = TRUE)
 ```
 
-## {pairwiseCI}
+## {coin}
 
 ```{r}
-stats::wilcox_test(value ~ as.factor(treat), data = all, conf.int = TRUE)
+coin::wilcox_test(value ~ as.factor(treat), data = all, conf.int = TRUE)
 ```

--- a/R/nparestimate.qmd
+++ b/R/nparestimate.qmd
@@ -40,7 +40,7 @@ all$treat <- treat
 The base function provides the Hodges-Lehmann estimate and the Moses confidence interval. The function will provide warnings in case of ties in the data and will not provide the exact confidence interval.
 
 ```{r}
-wt <- wilcox.test(x, y, exact = TRUE, conf.int = TRUE)
+wt <- stats::wilcox.test(x, y, exact = TRUE, conf.int = TRUE)
 
 # Hodges-Lehmann estimator
 wt$estimate
@@ -52,11 +52,11 @@ wt$conf.int
 **Note**: You can process the long format also for *wilcox.test* using the formula structure:
 
 ```{r}
-wilcox.test(all$value ~ all$treat, exact = TRUE, conf.int = TRUE)
+stats::wilcox.test(all$value ~ all$treat, exact = TRUE, conf.int = TRUE)
 ```
 
 ## {pairwiseCI}
 
 ```{r}
-wilcox_test(value ~ as.factor(treat), data = all, conf.int = TRUE)
+stats::wilcox_test(value ~ as.factor(treat), data = all, conf.int = TRUE)
 ```

--- a/R/rbmi_continuous_joint.qmd
+++ b/R/rbmi_continuous_joint.qmd
@@ -1,29 +1,25 @@
 ---
-title: "<R> <Reference-Based Multiple Imputation (joint modelling): Continuous Data>"
+title: "Reference-Based Multiple Imputation (joint modelling): Continuous Data"
 ---
 
 ## Libraries
 
-### General
 ```{r}
 #| output: false
 #| warning: false
+
+# General
 library(dplyr)
 library(tidyr)
 library(gt)
 library(labelled)
-```
 
-### Methodology specific
-```{r}
-#| output: false
-#| warning: false
+# Methodlolgy specific
 library(mmrm)
 library(emmeans)
 library(rbmi)
 library(mice) # only used md.pattern()
 ```
-
 
 ## Reference-based multiple imputation (rbmi)
 
@@ -78,7 +74,7 @@ dat <- antidepressant_data |>
     CHANGE
   ) |>
   dplyr::mutate(THERAPY = factor(THERAPY, levels = c("PLACEBO", "DRUG"))) |>
-  remove_labels()
+  labelled::remove_labels()
 
 gt(head(dat, n = 10))
 ```
@@ -116,7 +112,7 @@ dat_wide = dat |>
 
 dat_wide |>
   dplyr::select(starts_with("VISIT_")) |>
-  md.pattern(plot = TRUE, rotate.names = TRUE)
+  mice::md.pattern(plot = TRUE, rotate.names = TRUE)
 ```
 
 ## Complete case analysis
@@ -125,7 +121,7 @@ A complete case analysis is performed using mixed model for repeated measures (M
 
 ```{r}
 #| label: mmrm fit
-mmrm_fit = mmrm(
+mmrm_fit = mmrm::mmrm(
   CHANGE ~
     1 +
       THERAPY +
@@ -155,7 +151,8 @@ em = emmeans::emmeans(
 )
 
 em_contrast = broom::tidy(em$contrasts, conf.int = TRUE, conf.level = 0.95)
-gt(em_contrast) |>
+em_contrast |>
+  gt() |>
   fmt_number(decimals = 3)
 ```
 
@@ -170,7 +167,7 @@ The code presented here is based on the `rbmi` package  [quickstart vignette](ht
 
 ```{r}
 #| label: MAR - create dataset 1
-dat_expand <- expand_locf(
+dat_expand <- rbmi::expand_locf(
   dat,
   PATIENT = levels(dat$PATIENT), # expand by PATIENT and VISIT
   VISIT = levels(dat$VISIT),
@@ -181,10 +178,16 @@ dat_expand <- expand_locf(
 ```
 
 For example, the data of patient 1513 in the original data and expanded data are:
+
 ```{r}
 #| label: MAR - create dataset 2
-gt(dat |> dplyr::filter(PATIENT == "1513"))
-gt(dat_expand |> dplyr::filter(PATIENT == "1513"))
+dat |>
+  dplyr::filter(PATIENT == "1513") |>
+  gt()
+
+dat_expand |>
+  dplyr::filter(PATIENT == "1513") |>
+  gt()
 ```
 
 Next, a dataset must be created specifying which data points should be imputed with the specified imputation strategy. The dataset `dat_ice` is created which specifies the first visit affected by an intercurrent event (ICE) and the imputation strategy for handling missing outcome data after the ICE. At most one ICE which is to be imputed is allowed per subject. In the example, the subject’s first visit affected by the ICE “study drug discontinuation” corresponds to the first terminal missing observation
@@ -204,6 +207,7 @@ gt(head(dat_ice))
 ```
 
 In this dataset, subject 3618 has an intermittent missing values which does not correspond to a study drug discontinuation. We therefore remove this subject from `dat_ice`. In the later imputation step, it will automatically be imputed under the default MAR assumption.
+
 ```{r}
 #| label: MAR - create dataset 4
 dat_ice <- dat_ice[-which(dat_ice$PATIENT == 3618), ]
@@ -218,7 +222,7 @@ The `draws()` function fits the imputation model and stores the corresponding pa
 
 ```{r}
 #| label: MAR - draw step
-vars <- set_vars(
+vars <- rbmi::set_vars(
   outcome = "CHANGE",
   visit = "VISIT",
   subjid = "PATIENT",
@@ -226,9 +230,9 @@ vars <- set_vars(
   covariates = c("GENDER", "BASVAL*VISIT", "THERAPY*VISIT")
 )
 
-method <- method_bayes(
+method <- rbmi::method_bayes(
   n_samples = 500,
-  control = control_bayes(warmup = 500, thin = 10)
+  control = rbmi::control_bayes(warmup = 500, thin = 10)
 )
 
 set.seed(12345)
@@ -249,18 +253,20 @@ The next step is to use the parameters from the imputation model to generate the
 
 ```{r}
 #| label: MAR - impute step
-imputeObj <- impute(draws = drawObj, references = NULL)
+imputeObj <- rbmi::impute(draws = drawObj, references = NULL)
 ```
 
 In case we would like to access the imputed datasets, we can use the `extract_imputed_dfs()` function. For example, the imputed values in the 10th imputed dataset for patient 1513 are:
 
 ```{r}
 #| label: MAR impute step 2
-imputed_dfs = extract_imputed_dfs(imputeObj)
+imputed_dfs = rbmi::extract_imputed_dfs(imputeObj)
 MI_10 = imputed_dfs[[10]]
 MI_10$PATIENT_ID = dat_expand$PATIENT
 
-gt(MI_10 |> dplyr::filter(PATIENT_ID == "1513"))
+MI_10 |>
+  dplyr::filter(PATIENT_ID == "1513") |>
+  gt()
 ```
 
 ### Analyse imputed datasets
@@ -272,7 +278,7 @@ Note: In Appendix 1 below we show how you can easily use a different analysis me
 
 ```{r}
 #| label: MAR - analyse
-vars_analyse <- set_vars(
+vars_analyse <- rbmi::set_vars(
   outcome = "CHANGE",
   visit = "VISIT",
   subjid = "PATIENT",
@@ -280,18 +286,19 @@ vars_analyse <- set_vars(
   covariates = c("BASVAL", "GENDER")
 )
 
-anaObj <- analyse(
+anaObj <- rbmi::analyse(
   imputations = imputeObj,
   fun = ancova,
   vars = vars_analyse
 )
 ```
 
-
 ### Pool results
+
 Finally, the `pool()` function can be used to summarise the analysis results across multiple imputed datasets to provide an overall statistic with a standard error, confidence intervals and a p-value for the hypothesis test of the null hypothesis that the effect is equal to 0. Since we used `method_bayes()`, pooling and inference are based on Rubin’s rules.
 
 Here, the treatment difference at visit 7 is of interest. Since we set PLACEBO as the first factor in the variable `THERAPY` this corresponds to `ref`, whereas DRUG corresponds to `alt`.
+
 ```{r}
 #| label: MAR - pool
 poolObj <- rbmi::pool(anaObj, conf.level = 0.95, alternative = "two.sided")
@@ -318,7 +325,7 @@ dat_ice <- dat_expand |>
   select(PATIENT, VISIT) |>
   mutate(strategy = "CR")
 
-imputeObj <- impute(
+imputeObj <- rbmi::impute(
   drawObj,
   references = c("PLACEBO" = "PLACEBO", "DRUG" = "PLACEBO")
 )
@@ -339,7 +346,7 @@ dat_ice <- dat_expand |>
   mutate(strategy = "CR")
 dat_ice <- dat_ice[-which(dat_ice$PATIENT == 3618), ]
 
-vars <- set_vars(
+vars <- rbmi::set_vars(
   outcome = "CHANGE",
   visit = "VISIT",
   subjid = "PATIENT",
@@ -347,13 +354,13 @@ vars <- set_vars(
   covariates = c("GENDER", "BASVAL*VISIT", "THERAPY*VISIT")
 )
 
-method <- method_bayes(
+method <- rbmi::method_bayes(
   n_samples = 500,
-  control = control_bayes(warmup = 500, thin = 10)
+  control = rbmi::control_bayes(warmup = 500, thin = 10)
 )
 
 set.seed(12345)
-drawObj <- draws(
+drawObj <- rbmi::draws(
   data = dat_expand,
   data_ice = dat_ice,
   vars = vars,
@@ -361,12 +368,12 @@ drawObj <- draws(
   quiet = TRUE
 )
 
-imputeObj <- impute(
+imputeObj <- rbmi::impute(
   drawObj,
   references = c("PLACEBO" = "PLACEBO", "DRUG" = "PLACEBO")
 )
 
-vars_analyse <- set_vars(
+vars_analyse <- rbmi::set_vars(
   outcome = "CHANGE",
   visit = "VISIT",
   subjid = "PATIENT",
@@ -374,12 +381,17 @@ vars_analyse <- set_vars(
   covariates = c("BASVAL", "GENDER")
 )
 
-anaObj <- analyse(imputations = imputeObj, fun = ancova, vars = vars_analyse)
+anaObj <- rbmi::analyse(
+  imputations = imputeObj,
+  fun = ancova,
+  vars = vars_analyse
+)
 
 poolObj <- rbmi::pool(anaObj, conf.level = 0.95, alternative = "two.sided")
 ```
 
 The results for M=500 imputed datasets using the MNAR CR approach are:
+
 ```{r}
 #| label: MNAR CR - results
 poolObj |>
@@ -403,7 +415,7 @@ dat_ice <- dat_expand |>
   select(PATIENT, VISIT) |>
   mutate(strategy = "JR")
 
-imputeObj <- impute(
+imputeObj <- rbmi::impute(
   drawObj,
   references = c("PLACEBO" = "PLACEBO", "DRUG" = "PLACEBO")
 )
@@ -422,9 +434,10 @@ dat_ice <- dat_expand |>
   ungroup() |>
   select(PATIENT, VISIT) |>
   mutate(strategy = "JR")
+
 dat_ice <- dat_ice[-which(dat_ice$PATIENT == 3618), ]
 
-vars <- set_vars(
+vars <- rbmi::set_vars(
   outcome = "CHANGE",
   visit = "VISIT",
   subjid = "PATIENT",
@@ -432,13 +445,13 @@ vars <- set_vars(
   covariates = c("GENDER", "BASVAL*VISIT", "THERAPY*VISIT")
 )
 
-method <- method_bayes(
+method <- rbmi::method_bayes(
   n_samples = 500,
-  control = control_bayes(warmup = 500, thin = 10)
+  control = rbmi::control_bayes(warmup = 500, thin = 10)
 )
 
 set.seed(12345)
-drawObj <- draws(
+drawObj <- rbmi::draws(
   data = dat_expand,
   data_ice = dat_ice,
   vars = vars,
@@ -446,12 +459,12 @@ drawObj <- draws(
   quiet = TRUE
 )
 
-imputeObj <- impute(
+imputeObj <- rbmi::impute(
   drawObj,
   references = c("PLACEBO" = "PLACEBO", "DRUG" = "PLACEBO")
 )
 
-vars_analyse <- set_vars(
+vars_analyse <- rbmi::set_vars(
   outcome = "CHANGE",
   visit = "VISIT",
   subjid = "PATIENT",
@@ -459,12 +472,17 @@ vars_analyse <- set_vars(
   covariates = c("BASVAL", "GENDER")
 )
 
-anaObj <- analyse(imputations = imputeObj, fun = ancova, vars = vars_analyse)
+anaObj <- rbmi::analyse(
+  imputations = imputeObj,
+  fun = ancova,
+  vars = vars_analyse
+)
 
 poolObj <- rbmi::pool(anaObj, conf.level = 0.95, alternative = "two.sided")
 ```
 
 The results for M=500 imputed datasets using the MNAR JR approach are:
+
 ```{r}
 #| label: MNAR JR - results
 poolObj |>
@@ -490,7 +508,7 @@ dat_ice <- dat_expand |>
   select(PATIENT, VISIT) |>
   mutate(strategy = "CIR")
 
-imputeObj <- impute(
+imputeObj <- rbmi::impute(
   drawObj,
   references = c("PLACEBO" = "PLACEBO", "DRUG" = "PLACEBO")
 )
@@ -509,6 +527,7 @@ dat_ice <- dat_expand |>
   ungroup() |>
   select(PATIENT, VISIT) |>
   mutate(strategy = "CIR")
+
 dat_ice <- dat_ice[-which(dat_ice$PATIENT == 3618), ]
 
 vars <- set_vars(
@@ -519,13 +538,13 @@ vars <- set_vars(
   covariates = c("GENDER", "BASVAL*VISIT", "THERAPY*VISIT")
 )
 
-method <- method_bayes(
+method <- rbmi::method_bayes(
   n_samples = 500,
   control = control_bayes(warmup = 500, thin = 10)
 )
 
 set.seed(12345)
-drawObj <- draws(
+drawObj <- rbmi::draws(
   data = dat_expand,
   data_ice = dat_ice,
   vars = vars,
@@ -533,12 +552,12 @@ drawObj <- draws(
   quiet = TRUE
 )
 
-imputeObj <- impute(
+imputeObj <- rbmi::impute(
   drawObj,
   references = c("PLACEBO" = "PLACEBO", "DRUG" = "PLACEBO")
 )
 
-vars_analyse <- set_vars(
+vars_analyse <- rbmi::set_vars(
   outcome = "CHANGE",
   visit = "VISIT",
   subjid = "PATIENT",
@@ -546,12 +565,17 @@ vars_analyse <- set_vars(
   covariates = c("BASVAL", "GENDER")
 )
 
-anaObj <- analyse(imputations = imputeObj, fun = ancova, vars = vars_analyse)
+anaObj <- rbmi::analyse(
+  imputations = imputeObj,
+  fun = ancova,
+  vars = vars_analyse
+)
 
 poolObj <- rbmi::pool(anaObj, conf.level = 0.95, alternative = "two.sided")
 ```
 
 The results for M=500 imputed datasets using the MNAR CIR approach are:
+
 ```{r}
 #| label: MNAR CIR - results
 poolObj |>
@@ -580,14 +604,14 @@ In the table we present the results of the different imputation strategies (and 
 | MI - MNAR CIR (M=2000) | -2.469 | 1.116 | -4.674 to -0.263 | 0.0285 |
 | MI - MNAR CIR (M=5000) | -2.479 | 1.112 | -4.676 to -0.282 | 0.0273 |
 
-
 ## Approximate Bayesian
+
 In the `draws()` function it is possible to specify other methods. For example, the approximate Bayesian MI `method_approxbayes()` which is based on bootstrapping. `draws()` returns the draws from the posterior distribution of the parameters using an approximate Bayesian approach, where the sampling from the posterior distribution is simulated by fitting the MMRM model on bootstrap samples of the original dataset.
 
 ```{r}
 #| label: ApproxBayes - changes
 #| eval: false
-method <- method_approxbayes(
+method <- rbmi::method_approxbayes(
   covariance = "us",
   threshold = 0.01,
   REML = TRUE,
@@ -602,13 +626,14 @@ In the table we present the results of the approximate Bayesian approach for a C
 | MI - MNAR CR (M=500)  | -2.415 | 1.109 | -4.617 to -0.210 | 0.0320 |
 | MI - MNAR CR (M=2000) | -2.403 | 1.112 | -4.600 to -0.205 | 0.0323 |
 
-
 ## Discussion
+
 A note on computational time: The total running time (including data loading, setting up data sets, MCMC run, imputing data and analysis MI data) for M=500 was about 26 seconds on a personal laptop. It increased to about 92 seconds for M=2000. Computational time was similar across different imputation strategies.
 
 With a small number of `n_samples` in `method_bayes()` a warning could pop-up "The largest R-hat is 1.08, indicating chains have not mixed. Running the chains for more iterations may help". Increasing the number of `n_samples` will mostly solve this warning. For example, for this data example, this message is received when setting `n_samples` equal to a number below 100.
 
 ## Appendix 1: mmrm as analysis model
+
 In the `analyse()` function (at the moment of writing) the only available analysis function is `ancova`. However, the user is able to specify its own analysis function. See the `analyse()` function for more details.
 
 Another possibility (although, not the most efficient) is to implement a for loop in which the model is fit on each imputed dataset. The obtained results could then be pooled using Rubin's rule. For example, suppose an MMRM should be fit on each imputed dataset:
@@ -617,7 +642,7 @@ Another possibility (although, not the most efficient) is to implement a for loo
 #| label: mmrm analyse
 mmrm_analyse_mi_function <- function(Impute_Obj) {
   # create all imputed datasets
-  imputed_dfs = extract_imputed_dfs(Impute_Obj)
+  imputed_dfs = rbmi::extract_imputed_dfs(Impute_Obj)
 
   # create empty vectors to store mmrm analysis results
   est_vec = sd_vec = df_vec = NULL
@@ -625,7 +650,7 @@ mmrm_analyse_mi_function <- function(Impute_Obj) {
   # for loop to save estimates per imputation
   for (k in 1:length(imputed_dfs)) {
     temp_dat = imputed_dfs[[k]]
-    mmrm_fit_temp = mmrm(
+    mmrm_fit_temp = mmrm::mmrm(
       CHANGE ~
         1 +
           THERAPY +
@@ -661,6 +686,7 @@ mmrm_analyse_mi_function <- function(Impute_Obj) {
 ```
 
 The following code then performs the analysis and pooling
+
 ```{r}
 #| label: mmrm analyse 2
 #| eval: false

--- a/R/rbmi_continuous_joint.qmd
+++ b/R/rbmi_continuous_joint.qmd
@@ -21,7 +21,7 @@ library(labelled)
 library(mmrm)
 library(emmeans)
 library(rbmi)
-library(mice)  # only used md.pattern()
+library(mice) # only used md.pattern()
 ```
 
 
@@ -63,68 +63,99 @@ A publicly available example [dataset](https://r-packages.io/datasets/antidepres
 
 The relevant endpoint is the Hamilton 17-item depression rating scale (HAMD17) which was assessed at baseline and at weeks 1, 2, 4, and 6 (visits 4-7). Study drug discontinuation occurred in 24% (20/84) of subjects from the active drug and 26% (23/88) of subjects from placebo. All data after study drug discontinuation are missing. 
 
-```{r create data}
+```{r}
+#| label: create data
 data("antidepressant_data")
-dat <- antidepressant_data %>%
-  dplyr::select(PATIENT, GENDER, THERAPY, RELDAYS, VISIT, BASVAL, HAMDTL17, CHANGE) %>%
-  dplyr::mutate(THERAPY = factor(THERAPY, levels = c("PLACEBO", "DRUG"))) %>%
+dat <- antidepressant_data |>
+  dplyr::select(
+    PATIENT,
+    GENDER,
+    THERAPY,
+    RELDAYS,
+    VISIT,
+    BASVAL,
+    HAMDTL17,
+    CHANGE
+  ) |>
+  dplyr::mutate(THERAPY = factor(THERAPY, levels = c("PLACEBO", "DRUG"))) |>
   remove_labels()
 
 gt(head(dat, n = 10))
 ```
 
 The number of patients per visit and arm are:
-```{r explore data 1}
-dat %>%
-  group_by(VISIT, THERAPY) %>%
+
+```{r}
+#| label: explore data 1
+dat |>
+  group_by(VISIT, THERAPY) |>
   dplyr::summarise(N = n())
 ```
 
 The mean change from baseline of the endpoint (Hamilton 17-item depression rating scale, HAMD17) per visit per treatment group using only the complete cases are:
-```{r explore data mean per visit}
-dat %>%
-  group_by(VISIT, THERAPY) %>%
-  dplyr::summarise(N = n(),
-                   MEAN = mean(CHANGE))
+
+```{r}
+#| label: explore data mean per visit
+dat |>
+  group_by(VISIT, THERAPY) |>
+  dplyr::summarise(N = n(), MEAN = mean(CHANGE))
 ```
 
 The missingness pattern is show below (1=observed data point (blue), 0=missing data point (red)). The incomplete data is primarily monotone in nature. 128 patients have complete data for all visits (all 1's at each visit). 20, 10 and 13 patients have 1, 2 or 3  monotone missing data, respectively. Further, there is a single additional intermittent missing observation (patient 3618).
-```{r explore data 2}
-dat_wide = dat %>%
-  dplyr::select(PATIENT, VISIT, CHANGE) %>%
-  pivot_wider(id_cols = PATIENT,
-              names_from = VISIT,
-              names_prefix = "VISIT_",
-              values_from = CHANGE)
 
-dat_wide %>%
-  dplyr::select(starts_with("VISIT_")) %>%
-  md.pattern(plot=TRUE, rotate.names = TRUE)
+```{r}
+#| label: explore data 2
+dat_wide = dat |>
+  dplyr::select(PATIENT, VISIT, CHANGE) |>
+  pivot_wider(
+    id_cols = PATIENT,
+    names_from = VISIT,
+    names_prefix = "VISIT_",
+    values_from = CHANGE
+  )
+
+dat_wide |>
+  dplyr::select(starts_with("VISIT_")) |>
+  md.pattern(plot = TRUE, rotate.names = TRUE)
 ```
 
-
 ## Complete case analysis
+
 A complete case analysis is performed using mixed model for repeated measures (MMRM) with covariates: treatment [THERAPY], gender [GENDER], visit [VISIT] as factors; baseline score [BASVAL] as continuous; and visit-by-treatment [THERAPY * VISIT] interaction, and visit-by-baseline [BASVAL * VISIT] interaction. An unstructured covariance matrix is used.
 
-```{r mmrm fit}
-mmrm_fit = mmrm(CHANGE ~ 1 + THERAPY + GENDER + VISIT + BASVAL + THERAPY*VISIT + BASVAL*VISIT +
-                  us(VISIT | PATIENT),
-                data = dat,
-                reml = TRUE)
+```{r}
+#| label: mmrm fit
+mmrm_fit = mmrm(
+  CHANGE ~
+    1 +
+      THERAPY +
+      GENDER +
+      VISIT +
+      BASVAL +
+      THERAPY * VISIT +
+      BASVAL * VISIT +
+      us(VISIT | PATIENT),
+  data = dat,
+  reml = TRUE
+)
 summary(mmrm_fit)
 ```
 
 Using the `emmeans` package/function least square means and contrast can be obtained.
-```{r mmrm emmeans}
-em = emmeans::emmeans(mmrm_fit,
-                      specs = trt.vs.ctrl ~ THERAPY*VISIT,
-                      at = list(VISIT = "7"),
-                      level = 0.95,
-                      adjust = "none",
-                      mode = "df.error")
 
-em_contrast = broom::tidy(em$contrasts, conf.int=TRUE, conf.level=0.95)
-gt(em_contrast) %>%
+```{r}
+#| label: mmrm emmeans
+em = emmeans::emmeans(
+  mmrm_fit,
+  specs = trt.vs.ctrl ~ THERAPY * VISIT,
+  at = list(VISIT = "7"),
+  level = 0.95,
+  adjust = "none",
+  mode = "df.error"
+)
+
+em_contrast = broom::tidy(em$contrasts, conf.int = TRUE, conf.level = 0.95)
+gt(em_contrast) |>
   fmt_number(decimals = 3)
 ```
 
@@ -137,41 +168,45 @@ The code presented here is based on the `rbmi` package  [quickstart vignette](ht
 ### Create needed datasets and specify imputation strategy
 `rbmi` expects its input dataset to be complete; that is, there must be one row per subject for each visit (note: in clinical trials ADAMs typically do not have this required complete data structure). Missing outcome values should be coded as `NA`, while missing covariate values are not allowed. If the dataset is incomplete, then the `expand_locf()` function can be used to add any missing rows, using LOCF imputation to carry forward the observed baseline covariate values to visits with missing outcomes.
 
-```{r MAR - create dataset 1}
+```{r}
+#| label: MAR - create dataset 1
 dat_expand <- expand_locf(
   dat,
-  PATIENT = levels(dat$PATIENT),  # expand by PATIENT and VISIT
+  PATIENT = levels(dat$PATIENT), # expand by PATIENT and VISIT
   VISIT = levels(dat$VISIT),
-  vars = c("BASVAL", "THERAPY", "GENDER"),  # complete covariates using LOCF
+  vars = c("BASVAL", "THERAPY", "GENDER"), # complete covariates using LOCF
   group = c("PATIENT"),
-  order = c("PATIENT", "VISIT")   # sort
+  order = c("PATIENT", "VISIT") # sort
 )
 ```
 
 For example, the data of patient 1513 in the original data and expanded data are:
-```{r MAR - create dataset 2}
-gt(dat %>% dplyr::filter(PATIENT == "1513"))
-gt(dat_expand %>% dplyr::filter(PATIENT == "1513"))
+```{r}
+#| label: MAR - create dataset 2
+gt(dat |> dplyr::filter(PATIENT == "1513"))
+gt(dat_expand |> dplyr::filter(PATIENT == "1513"))
 ```
 
 Next, a dataset must be created specifying which data points should be imputed with the specified imputation strategy. The dataset `dat_ice` is created which specifies the first visit affected by an intercurrent event (ICE) and the imputation strategy for handling missing outcome data after the ICE. At most one ICE which is to be imputed is allowed per subject. In the example, the subject’s first visit affected by the ICE “study drug discontinuation” corresponds to the first terminal missing observation
 
-```{r MAR - create dataset 3}
-dat_ice <- dat_expand %>% 
-  arrange(PATIENT, VISIT) %>% 
-  filter(is.na(CHANGE)) %>% 
-  group_by(PATIENT) %>% 
-  slice(1) %>%
-  ungroup() %>% 
-  select(PATIENT, VISIT) %>% 
+```{r}
+#| label: MAR create dataset 3
+dat_ice <- dat_expand |>
+  arrange(PATIENT, VISIT) |>
+  filter(is.na(CHANGE)) |>
+  group_by(PATIENT) |>
+  slice(1) |>
+  ungroup() |>
+  select(PATIENT, VISIT) |>
   mutate(strategy = "MAR")
 
 gt(head(dat_ice))
 ```
 
 In this dataset, subject 3618 has an intermittent missing values which does not correspond to a study drug discontinuation. We therefore remove this subject from `dat_ice`. In the later imputation step, it will automatically be imputed under the default MAR assumption.
-```{r MAR - create dataset 4}
-dat_ice <- dat_ice[-which(dat_ice$PATIENT == 3618),]
+```{r}
+#| label: MAR - create dataset 4
+dat_ice <- dat_ice[-which(dat_ice$PATIENT == 3618), ]
 ```
 
 ### Fit imputation model and draw posterior parameters
@@ -181,7 +216,8 @@ The `method` object specifies the statistical method used to fit the imputation 
 
 The `draws()` function fits the imputation model and stores the corresponding parameter estimates and Bayesian posterior parameter draws.
 
-```{r MAR - draw step}
+```{r}
+#| label: MAR - draw step
 vars <- set_vars(
   outcome = "CHANGE",
   visit = "VISIT",
@@ -211,19 +247,20 @@ drawObj
 
 The next step is to use the parameters from the imputation model to generate the imputed datasets. This is done via the `impute()` function. The function only has two key inputs: the imputation model output from `draws()` and the `references` groups relevant to reference-based imputation methods. Since we are using the MAR approach here, we can set it to NULL.
 
-```{r MAR - impute step}
-imputeObj <- impute(draws = drawObj,
-                    references = NULL)
+```{r}
+#| label: MAR - impute step
+imputeObj <- impute(draws = drawObj, references = NULL)
 ```
 
 In case we would like to access the imputed datasets, we can use the `extract_imputed_dfs()` function. For example, the imputed values in the 10th imputed dataset for patient 1513 are:
 
-```{r MAR - impute step 2}
+```{r}
+#| label: MAR impute step 2
 imputed_dfs = extract_imputed_dfs(imputeObj)
 MI_10 = imputed_dfs[[10]]
 MI_10$PATIENT_ID = dat_expand$PATIENT
 
-gt(MI_10 %>% dplyr::filter(PATIENT_ID == "1513"))
+gt(MI_10 |> dplyr::filter(PATIENT_ID == "1513"))
 ```
 
 ### Analyse imputed datasets
@@ -233,7 +270,8 @@ The `ancova()` function uses the `set_vars()` function which determines the name
 
 Note: In Appendix 1 below we show how you can easily use a different analysis method (e.g., mmrm).
 
-```{r MAR - analyse}
+```{r}
+#| label: MAR - analyse
 vars_analyse <- set_vars(
   outcome = "CHANGE",
   visit = "VISIT",
@@ -242,9 +280,11 @@ vars_analyse <- set_vars(
   covariates = c("BASVAL", "GENDER")
 )
 
-anaObj <- analyse(imputations = imputeObj,
-                  fun = ancova, 
-                  vars = vars_analyse)
+anaObj <- analyse(
+  imputations = imputeObj,
+  fun = ancova,
+  vars = vars_analyse
+)
 ```
 
 
@@ -252,14 +292,13 @@ anaObj <- analyse(imputations = imputeObj,
 Finally, the `pool()` function can be used to summarise the analysis results across multiple imputed datasets to provide an overall statistic with a standard error, confidence intervals and a p-value for the hypothesis test of the null hypothesis that the effect is equal to 0. Since we used `method_bayes()`, pooling and inference are based on Rubin’s rules.
 
 Here, the treatment difference at visit 7 is of interest. Since we set PLACEBO as the first factor in the variable `THERAPY` this corresponds to `ref`, whereas DRUG corresponds to `alt`.
-```{r MAR - pool}
-poolObj <- rbmi::pool(anaObj,
-                      conf.level = 0.95, 
-                      alternative = "two.sided")
+```{r}
+#| label: MAR - pool
+poolObj <- rbmi::pool(anaObj, conf.level = 0.95, alternative = "two.sided")
 
-poolObj %>%
-  data.frame() %>%
-  dplyr::filter(grepl("7", parameter)) %>%
+poolObj |>
+  data.frame() |>
+  dplyr::filter(grepl("7", parameter)) |>
   gt()
 ```
 
@@ -267,36 +306,38 @@ poolObj %>%
 ## rbmi: MNAR CR approach
 The following changes need to be made in the code above to apply the Copy Reference (CR) approach in `rbmi`. For `dat_ice` the strategy need to be changed to CR. In the `impute()` step the `references` need to be specified. Here we set the reference for the DRUG group to PLACEBO.
 
-```{r MNAR CR - changes}
+```{r}
+#| label: MAR CR - changes
 #| eval: false
-dat_ice <- dat_expand %>% 
-  arrange(PATIENT, VISIT) %>% 
-  filter(is.na(CHANGE)) %>% 
-  group_by(PATIENT) %>% 
-  slice(1) %>%
-  ungroup() %>% 
-  select(PATIENT, VISIT) %>% 
+dat_ice <- dat_expand |>
+  arrange(PATIENT, VISIT) |>
+  filter(is.na(CHANGE)) |>
+  group_by(PATIENT) |>
+  slice(1) |>
+  ungroup() |>
+  select(PATIENT, VISIT) |>
   mutate(strategy = "CR")
 
 imputeObj <- impute(
   drawObj,
-  references = c("PLACEBO"="PLACEBO", "DRUG"="PLACEBO")
+  references = c("PLACEBO" = "PLACEBO", "DRUG" = "PLACEBO")
 )
 ```
 
-```{r MNAR CR - evaluate}
+```{r}
+#| label: MNAR CR - evaluate
 #| echo: false
 #| include: false
 
-dat_ice <- dat_expand %>% 
-  arrange(PATIENT, VISIT) %>% 
-  filter(is.na(CHANGE)) %>% 
-  group_by(PATIENT) %>% 
-  slice(1) %>%
-  ungroup() %>% 
-  select(PATIENT, VISIT) %>% 
+dat_ice <- dat_expand |>
+  arrange(PATIENT, VISIT) |>
+  filter(is.na(CHANGE)) |>
+  group_by(PATIENT) |>
+  slice(1) |>
+  ungroup() |>
+  select(PATIENT, VISIT) |>
   mutate(strategy = "CR")
-dat_ice <- dat_ice[-which(dat_ice$PATIENT == 3618),]
+dat_ice <- dat_ice[-which(dat_ice$PATIENT == 3618), ]
 
 vars <- set_vars(
   outcome = "CHANGE",
@@ -322,8 +363,8 @@ drawObj <- draws(
 
 imputeObj <- impute(
   drawObj,
-  references = c("PLACEBO"="PLACEBO", "DRUG"="PLACEBO")
-  )
+  references = c("PLACEBO" = "PLACEBO", "DRUG" = "PLACEBO")
+)
 
 vars_analyse <- set_vars(
   outcome = "CHANGE",
@@ -333,58 +374,55 @@ vars_analyse <- set_vars(
   covariates = c("BASVAL", "GENDER")
 )
 
-anaObj <- analyse(imputations = imputeObj,
-                  fun = ancova, 
-                  vars = vars_analyse)  
-  
-poolObj <- rbmi::pool(anaObj,
-                      conf.level = 0.95, 
-                      alternative = "two.sided")
+anaObj <- analyse(imputations = imputeObj, fun = ancova, vars = vars_analyse)
+
+poolObj <- rbmi::pool(anaObj, conf.level = 0.95, alternative = "two.sided")
 ```
 
 The results for M=500 imputed datasets using the MNAR CR approach are:
-```{r MNAR CR - results}
-poolObj %>%
-  data.frame() %>%
-  dplyr::filter(grepl("7", parameter)) %>%
+```{r}
+#| label: MNAR CR - results
+poolObj |>
+  data.frame() |>
+  dplyr::filter(grepl("7", parameter)) |>
   gt()
 ```
-
-
 
 ## rbmi: MNAR JR approach
 The following changes need to be made in the code above to apply the Jump to Reference (JR) approach in `rbmi`. For `dat_ice` the strategy need to be changed to JR. In the `impute()` step the `references` need to be specified. Here we set the reference for the DRUG group to PLACEBO.
 
-```{r MNAR JR - changes}
+```{r}
+#| label: MNAR JR - changes
 #| eval: false
-dat_ice <- dat_expand %>% 
-  arrange(PATIENT, VISIT) %>% 
-  filter(is.na(CHANGE)) %>% 
-  group_by(PATIENT) %>% 
-  slice(1) %>%
-  ungroup() %>% 
-  select(PATIENT, VISIT) %>% 
+dat_ice <- dat_expand |>
+  arrange(PATIENT, VISIT) |>
+  filter(is.na(CHANGE)) |>
+  group_by(PATIENT) |>
+  slice(1) |>
+  ungroup() |>
+  select(PATIENT, VISIT) |>
   mutate(strategy = "JR")
 
 imputeObj <- impute(
   drawObj,
-  references = c("PLACEBO"="PLACEBO", "DRUG"="PLACEBO")
+  references = c("PLACEBO" = "PLACEBO", "DRUG" = "PLACEBO")
 )
 ```
 
-```{r MNAR JR - evaluate}
+```{r}
+#| label: MNAR JR - evaluate
 #| echo: false
 #| include: false
 
-dat_ice <- dat_expand %>% 
-  arrange(PATIENT, VISIT) %>% 
-  filter(is.na(CHANGE)) %>% 
-  group_by(PATIENT) %>% 
-  slice(1) %>%
-  ungroup() %>% 
-  select(PATIENT, VISIT) %>% 
+dat_ice <- dat_expand |>
+  arrange(PATIENT, VISIT) |>
+  filter(is.na(CHANGE)) |>
+  group_by(PATIENT) |>
+  slice(1) |>
+  ungroup() |>
+  select(PATIENT, VISIT) |>
   mutate(strategy = "JR")
-dat_ice <- dat_ice[-which(dat_ice$PATIENT == 3618),]
+dat_ice <- dat_ice[-which(dat_ice$PATIENT == 3618), ]
 
 vars <- set_vars(
   outcome = "CHANGE",
@@ -410,8 +448,8 @@ drawObj <- draws(
 
 imputeObj <- impute(
   drawObj,
-  references = c("PLACEBO"="PLACEBO", "DRUG"="PLACEBO")
-  )
+  references = c("PLACEBO" = "PLACEBO", "DRUG" = "PLACEBO")
+)
 
 vars_analyse <- set_vars(
   outcome = "CHANGE",
@@ -421,20 +459,17 @@ vars_analyse <- set_vars(
   covariates = c("BASVAL", "GENDER")
 )
 
-anaObj <- analyse(imputations = imputeObj,
-                  fun = ancova, 
-                  vars = vars_analyse)  
-  
-poolObj <- rbmi::pool(anaObj,
-                      conf.level = 0.95, 
-                      alternative = "two.sided")
+anaObj <- analyse(imputations = imputeObj, fun = ancova, vars = vars_analyse)
+
+poolObj <- rbmi::pool(anaObj, conf.level = 0.95, alternative = "two.sided")
 ```
 
 The results for M=500 imputed datasets using the MNAR JR approach are:
-```{r MNAR JR - results}
-poolObj %>%
-  data.frame() %>%
-  dplyr::filter(grepl("7", parameter)) %>%
+```{r}
+#| label: MNAR JR - results
+poolObj |>
+  data.frame() |>
+  dplyr::filter(grepl("7", parameter)) |>
   gt()
 ```
 
@@ -443,36 +478,38 @@ poolObj %>%
 ## rbmi: MNAR CIR approach
 The following changes need to be made in the code above to apply the Copy Increments in Reference (CIR) approach in `rbmi`. For `dat_ice` the strategy need to be changed to CIR. In the `impute()` step the `references` need to be specified. Here we set the reference for the DRUG group to PLACEBO.
 
-```{r MNAR CIR - changes}
+```{r}
+#| label: MNAR CIR - changes
 #| eval: false
-dat_ice <- dat_expand %>% 
-  arrange(PATIENT, VISIT) %>% 
-  filter(is.na(CHANGE)) %>% 
-  group_by(PATIENT) %>% 
-  slice(1) %>%
-  ungroup() %>% 
-  select(PATIENT, VISIT) %>% 
+dat_ice <- dat_expand |>
+  arrange(PATIENT, VISIT) |>
+  filter(is.na(CHANGE)) |>
+  group_by(PATIENT) |>
+  slice(1) |>
+  ungroup() |>
+  select(PATIENT, VISIT) |>
   mutate(strategy = "CIR")
 
 imputeObj <- impute(
   drawObj,
-  references = c("PLACEBO"="PLACEBO", "DRUG"="PLACEBO")
+  references = c("PLACEBO" = "PLACEBO", "DRUG" = "PLACEBO")
 )
 ```
 
-```{r MNAR CIR - evaluate}
+```{r}
+#| label: MNAR CIR - evaluate
 #| echo: false
 #| include: false
 
-dat_ice <- dat_expand %>% 
-  arrange(PATIENT, VISIT) %>% 
-  filter(is.na(CHANGE)) %>% 
-  group_by(PATIENT) %>% 
-  slice(1) %>%
-  ungroup() %>% 
-  select(PATIENT, VISIT) %>% 
+dat_ice <- dat_expand |>
+  arrange(PATIENT, VISIT) |>
+  filter(is.na(CHANGE)) |>
+  group_by(PATIENT) |>
+  slice(1) |>
+  ungroup() |>
+  select(PATIENT, VISIT) |>
   mutate(strategy = "CIR")
-dat_ice <- dat_ice[-which(dat_ice$PATIENT == 3618),]
+dat_ice <- dat_ice[-which(dat_ice$PATIENT == 3618), ]
 
 vars <- set_vars(
   outcome = "CHANGE",
@@ -498,8 +535,8 @@ drawObj <- draws(
 
 imputeObj <- impute(
   drawObj,
-  references = c("PLACEBO"="PLACEBO", "DRUG"="PLACEBO")
-  )
+  references = c("PLACEBO" = "PLACEBO", "DRUG" = "PLACEBO")
+)
 
 vars_analyse <- set_vars(
   outcome = "CHANGE",
@@ -509,20 +546,17 @@ vars_analyse <- set_vars(
   covariates = c("BASVAL", "GENDER")
 )
 
-anaObj <- analyse(imputations = imputeObj,
-                  fun = ancova, 
-                  vars = vars_analyse)  
-  
-poolObj <- rbmi::pool(anaObj,
-                      conf.level = 0.95, 
-                      alternative = "two.sided")
+anaObj <- analyse(imputations = imputeObj, fun = ancova, vars = vars_analyse)
+
+poolObj <- rbmi::pool(anaObj, conf.level = 0.95, alternative = "two.sided")
 ```
 
 The results for M=500 imputed datasets using the MNAR CIR approach are:
-```{r MNAR CIR - results}
-poolObj %>%
-  data.frame() %>%
-  dplyr::filter(grepl("7", parameter)) %>%
+```{r}
+#| label: MNAR CIR - results
+poolObj |>
+  data.frame() |>
+  dplyr::filter(grepl("7", parameter)) |>
   gt()
 ```
 
@@ -550,12 +584,13 @@ In the table we present the results of the different imputation strategies (and 
 ## Approximate Bayesian
 In the `draws()` function it is possible to specify other methods. For example, the approximate Bayesian MI `method_approxbayes()` which is based on bootstrapping. `draws()` returns the draws from the posterior distribution of the parameters using an approximate Bayesian approach, where the sampling from the posterior distribution is simulated by fitting the MMRM model on bootstrap samples of the original dataset.
 
-```{r ApproxBayes - changes}
+```{r}
+#| label: ApproxBayes - changes
 #| eval: false
 method <- method_approxbayes(
   covariance = "us",
   threshold = 0.01,
-  REML=TRUE,
+  REML = TRUE,
   n_samples = 500
 )
 ```
@@ -578,46 +613,56 @@ In the `analyse()` function (at the moment of writing) the only available analys
 
 Another possibility (although, not the most efficient) is to implement a for loop in which the model is fit on each imputed dataset. The obtained results could then be pooled using Rubin's rule. For example, suppose an MMRM should be fit on each imputed dataset:
 
-```{r mmrm analyse}
-mmrm_analyse_mi_function <- function(Impute_Obj){
+```{r}
+#| label: mmrm analyse
+mmrm_analyse_mi_function <- function(Impute_Obj) {
   # create all imputed datasets
   imputed_dfs = extract_imputed_dfs(Impute_Obj)
 
   # create empty vectors to store mmrm analysis results
   est_vec = sd_vec = df_vec = NULL
-  
+
   # for loop to save estimates per imputation
-  for (k in 1:length(imputed_dfs)){
+  for (k in 1:length(imputed_dfs)) {
     temp_dat = imputed_dfs[[k]]
-    mmrm_fit_temp = mmrm(CHANGE ~ 1 + THERAPY + VISIT + BASVAL * VISIT + THERAPY * VISIT + GENDER +
-                           us(VISIT | PATIENT),
-                         data = temp_dat,
-                         reml = TRUE)
-    em = emmeans::emmeans(mmrm_fit_temp,
-                          specs = trt.vs.ctrl ~ THERAPY * VISIT,
-                          at = list(VISIT = "7"),
-                          level = 0.95,
-                          adjust = "none",
-                          mode = "df.error")
+    mmrm_fit_temp = mmrm(
+      CHANGE ~
+        1 +
+          THERAPY +
+          VISIT +
+          BASVAL * VISIT +
+          THERAPY * VISIT +
+          GENDER +
+          us(VISIT | PATIENT),
+      data = temp_dat,
+      reml = TRUE
+    )
+    em = emmeans::emmeans(
+      mmrm_fit_temp,
+      specs = trt.vs.ctrl ~ THERAPY * VISIT,
+      at = list(VISIT = "7"),
+      level = 0.95,
+      adjust = "none",
+      mode = "df.error"
+    )
     est_vec[k] = summary(em$contrasts)$estimate
     sd_vec[k] = summary(em$contrasts)$SE
     df_vec[k] = summary(em$contrasts)$df
   }
-  
+
   # summarize results using rubin's rule
-  rr = rbmi:::rubin_rules(ests=est_vec, 
-                          ses = sd_vec,
-                          v_com = mean(df_vec))
+  rr = rbmi:::rubin_rules(ests = est_vec, ses = sd_vec, v_com = mean(df_vec))
   rr$se_t = sqrt(rr$var_t)
-  rr$t.stat =  rr$est_point / sqrt(rr$var_t)
-  rr$p_value = 2*pt(q = rr$t.stat, df = rr$df, lower.tail = TRUE)
-  
-  return(rr=rr)
+  rr$t.stat = rr$est_point / sqrt(rr$var_t)
+  rr$p_value = 2 * pt(q = rr$t.stat, df = rr$df, lower.tail = TRUE)
+
+  return(rr = rr)
 }
 ```
 
 The following code then performs the analysis and pooling
-```{r mmrm analyse 2}
+```{r}
+#| label: mmrm analyse 2
 #| eval: false
 mmrm_analyse_mi_function(Impute_Obj = imputeObj)
 ```
@@ -654,11 +699,12 @@ In the table we present the results of the Bayesian approach for a CR imputation
 ```{r}
 #| echo: false
 
-# List all the packages needed 
+# List all the packages needed
 si <- sessioninfo::session_info(c(
-  #Create a vector of all the packages used in this file 
+  #Create a vector of all the packages used in this file
 ))
 si
 ```
+
 :::
 

--- a/R/rounding.qmd
+++ b/R/rounding.qmd
@@ -6,7 +6,7 @@ title: "Rounding in R"
 #| echo: false
 #| include: false
 library(janitor)
-library(dplyr) 
+library(dplyr)
 ```
 
 ## round from R base
@@ -18,7 +18,7 @@ The **round(12.5,digits=1)** function tells R to round to 1 decimal place.
 However, rounding is dependent on OS services and on representation error since for example, if 0.15 is not represented exactly, if could actually be the number 0.15000000001 or 0.149999999999! The rounding rule applies to the represented number and not to the printed number, and so round(0.15, 1) could be either 0.1 or 0.2).
 
 ```{r}
-round(1:9/10+0.05,1)
+round(1:9 / 10 + 0.05, 1)
 ```
 
 ## round_half_up from package janitor
@@ -26,18 +26,21 @@ round(1:9/10+0.05,1)
 Note that the [janitor](https://sfirke.github.io/janitor/) package in R contains a function `round_half_up()` that rounds away from zero. In this case it rounds to the nearest whole number and 'away from zero' or 'rounding up' when equidistant, meaning that exactly 12.5 rounds to the integer 13.
 
 ```{r}
-#Example code
-my_number <-c(2.2,3.99,1.2345,7.876,13.8739)
+# Example code
+my_number <- c(2.2, 3.99, 1.2345, 7.876, 13.8739)
 
-r_0_dec <- round(my_number, digits=0);
-r_1_dec <- round(my_number, digits=1);
-r_2_dec <- round(my_number, digits=2);
-r_3_dec <- round(my_number, digits=3);
-
+r_0_dec <- round(my_number, digits = 0)
 r_0_dec
+
+r_1_dec <- round(my_number, digits = 1)
 r_1_dec
+
+r_2_dec <- round(my_number, digits = 2)
 r_2_dec
+
+r_3_dec <- round(my_number, digits = 3)
 r_3_dec
+
 ```
 
 If using the janitor package in R, and the function `round_half_up()`, the results would be the same with the exception of rounding 1.2345 to 3 decimal places where a result of 1.235 would be obtained instead of 1.234. However, in some rare cases, `round_half_up()` does not return result as expected. There are two kinds of cases for it. 1. Round down for positive decimal like 0.xx5.
@@ -49,35 +52,38 @@ round_half_up(524288.1255, digits = 3)
 The cause is that when the decimal is stored in binary, the value usually does not exactly the same with the original number. In the example above, 524288.1255 is stored as a value a little less than the original value. Then `round_half_up()` rounds it down.
 
 ```{r}
-options(digits=22)
+options(digits = 22)
 524288.1255
 ```
 
 In `round_half_up()`, a small decimal `sqrt(.Machine$double.eps)` is added before rounding. It avoids some incorrect rounding due to the stored numeric value is a little less than the original value, but does not cover all conditions.
 
 ```{r}
-round_half_up <- function (x, digits = 0) 
-{
-    posneg <- sign(x)
-    z <- abs(x) * 10^digits
-    z <- z + 0.5 + sqrt(.Machine$double.eps)
-    z <- trunc(z)
-    z <- z/10^digits
-    z * posneg
+round_half_up <- function(x, digits = 0) {
+  posneg <- sign(x)
+  z <- abs(x) * 10^digits
+  z <- z + 0.5 + sqrt(.Machine$double.eps)
+  z <- trunc(z)
+  z <- z / 10^digits
+  z * posneg
 }
 ```
 
 More examples can be found from the code below. It creates numeric values containing different digit numbers of integer part and decimal part, and all ending with 5 for rounding.
 
 ```{r}
-options(digits=15) #set digit number to display 
-int1 <- c(0,2^(1:19)) #create values of integer part
-round_digits <- 1:7 #define values of rounding digits
-dec1 <- 2^(-round_digits)+10^(-round_digits-1)*5 #create values of decimal part
-df1 <- cross_join(tibble(int1),tibble(dec1,round_digits)) |>
-  mutate(num1=int1+dec1) #combine integer part and decimal part
-df1 |> mutate(rounded_num=round_half_up(num1,round_digits)) |> #round the numbers
-  filter(rounded_num<num1) |>  #incorrect if rounded result is less than the original number
+options(digits = 15) # set digit number to display
+int1 <- c(0, 2^(1:19)) # create values of integer part
+round_digits <- 1:7 # define values of rounding digits
+
+dec1 <- 2^(-round_digits) + 10^(-round_digits - 1) * 5 # create values of decimal part
+
+df1 <- cross_join(tibble(int1), tibble(dec1, round_digits)) |>
+  mutate(num1 = int1 + dec1) # combine integer part and decimal part
+
+df1 |>
+  mutate(rounded_num = round_half_up(num1, round_digits)) |> # round the numbers
+  filter(rounded_num < num1) |> # incorrect if rounded result is less than the original number
   print.data.frame()
 ```
 
@@ -86,28 +92,28 @@ df1 |> mutate(rounded_num=round_half_up(num1,round_digits)) |> #round the number
 2.  Round up for positive decimal like 0.4999....
 
 ```{r}
-options(digits=16)
-round_half_up(1.4999999851,0)
-
+options(digits = 16)
+round_half_up(1.4999999851, 0)
 ```
 
 It occurs when the number is smaller than but so closed to 0.xx5. As described in point 1 above, in `round_half_up()`, a small decimal `sqrt(.Machine$double.eps)` is added before rounding, which causes a number bigger than 0.xx5 to be rounded. It occurs only when the decimal is long, so `round_half_up()` is still reliable.\
 And the added decimal `sqrt(.Machine$double.eps)` is necessary. Without it, or even replace it to a smaller decimal, there will be more incorrect results under point 1, as the example below. Some of them are common, e.g. rounding 16.1255 to 3 decimals.
 
 ```{r}
-#a new function to round away from zero, by replacing sqrt(.Machine$double.eps) in round_half_up to a smaller number
-round_half_up_test <- function (x, digits = 0){
+# a new function to round away from zero, by replacing sqrt(.Machine$double.eps) in round_half_up to a smaller number
+round_half_up_test <- function(x, digits = 0) {
   posneg <- sign(x)
   z <- abs(x) * 10^digits
-  z <- z + 0.5 + .Machine$double.eps *100
+  z <- z + 0.5 + .Machine$double.eps * 100
   z <- trunc(z)
-  z <- z/10^digits
+  z <- z / 10^digits
   z * posneg
 }
 
-options(digits=15) #set digit number to display 
-df1 |> mutate(rounded_num=round_half_up_test(num1,round_digits)) |> #round the numbers
-  filter(rounded_num<num1) |>  #incorrect if rounded result is less than the original number
+options(digits = 15)
+df1 |>
+  mutate(rounded_num = round_half_up_test(num1, round_digits)) |>
+  filter(rounded_num < num1) |>
   print.data.frame()
 ```
 
@@ -116,7 +122,9 @@ df1 |> mutate(rounded_num=round_half_up_test(num1,round_digits)) |> #round the n
 https://stackoverflow.com/a/12688836 discussed multiple algorithms to round away from zero, including the one implemented in `round_half_up()`. Below is another algorithm modified from it.
 
 ```{r}
-round_v2 <- function(x, digits = 0, eps = .Machine$double.eps) round(x + x * eps, digits = digits)
+round_v2 <- function(x, digits = 0, eps = .Machine$double.eps) {
+  round(x + x * eps, digits = digits)
+}
 ```
 
 Like `round_half_up()`, it also contains the two kinds of incorrect results. And like `round_half_up()`, a small decimal is added to make 0.xx5 round up. The parameter `eps` is provided to let user decide which small decimal to add.
@@ -132,5 +140,5 @@ The `cards::round5()` package does the same rounding as the `janitor::round_half
 So far, `round_half_up()` from package janitor (or `cards::round5()` ) is still one of the best solutions to round away from zero, though users may meet incorrect results in rare cases when the numbers are big or the decimal is long.
 
 ```{r}
-options(digits = 7) #This just returns the number of displayed digits back to the default
+options(digits = 7) # This just returns the number of displayed digits back to the default
 ```

--- a/R/rounding.qmd
+++ b/R/rounding.qmd
@@ -46,7 +46,7 @@ r_3_dec
 If using the janitor package in R, and the function `round_half_up()`, the results would be the same with the exception of rounding 1.2345 to 3 decimal places where a result of 1.235 would be obtained instead of 1.234. However, in some rare cases, `round_half_up()` does not return result as expected. There are two kinds of cases for it. 1. Round down for positive decimal like 0.xx5.
 
 ```{r}
-round_half_up(524288.1255, digits = 3)
+janitor::round_half_up(524288.1255, digits = 3)
 ```
 
 The cause is that when the decimal is stored in binary, the value usually does not exactly the same with the original number. In the example above, 524288.1255 is stored as a value a little less than the original value. Then `round_half_up()` rounds it down.

--- a/R/sample_s_equivalence.qmd
+++ b/R/sample_s_equivalence.qmd
@@ -29,10 +29,18 @@ It is anticipated that patients will have the same mean diastolic BP of 96 mmHg 
 
 ```{r}
 # TrialSize:
-TwoSampleMean.Equivalence(0.05,0.2,8,1,5,0)
+TwoSampleMean.Equivalence(0.05, 0.2, 8, 1, 5, 0)
 
 # SampleSize4ClinicalTrials:
-ssc_meancomp(design = 4L, ratio = 1, alpha = 0.05, power = 0.8, sd = 8, theta = 0, delta = 5)
+ssc_meancomp(
+  design = 4L,
+  ratio = 1,
+  alpha = 0.05,
+  power = 0.8,
+  sd = 8,
+  theta = 0,
+  delta = 5
+)
 
 ```
 
@@ -42,10 +50,18 @@ A client is interested in conducting a clinical trial to compare two cholesterol
 
 ```{r}
 # TrialSize:
-TwoSampleMean.Equivalence(0.05,0.2,0.1,1,0.05,0.01)
+TwoSampleMean.Equivalence(0.05, 0.2, 0.1, 1, 0.05, 0.01)
 
 # SampleSize4ClinicalTrials:
-ssc_meancomp(design = 4L, ratio = 1, alpha = 0.05, power = 0.8, sd = 0.1, theta = 0.01, delta = 0.05)
+ssc_meancomp(
+  design = 4L,
+  ratio = 1,
+  alpha = 0.05,
+  power = 0.8,
+  sd = 0.1,
+  theta = 0.01,
+  delta = 0.05
+)
 
 ```
 
@@ -57,7 +73,7 @@ Let's consider a standard standard two-sequence, two period crossover design for
 
 ```{r}
 # TrialSize:
-TwoSampleCrossOver.Equivalence(0.05,0.2,0.2,0.25,-0.1)
+TwoSampleCrossOver.Equivalence(0.05, 0.2, 0.2, 0.25, -0.1)
 
 ```
 

--- a/R/sample_s_equivalence.qmd
+++ b/R/sample_s_equivalence.qmd
@@ -29,10 +29,10 @@ It is anticipated that patients will have the same mean diastolic BP of 96 mmHg 
 
 ```{r}
 # TrialSize:
-TwoSampleMean.Equivalence(0.05, 0.2, 8, 1, 5, 0)
+TrialSize::TwoSampleMean.Equivalence(0.05, 0.2, 8, 1, 5, 0)
 
 # SampleSize4ClinicalTrials:
-ssc_meancomp(
+SampleSize4ClinicalTrials::ssc_meancomp(
   design = 4L,
   ratio = 1,
   alpha = 0.05,
@@ -50,10 +50,10 @@ A client is interested in conducting a clinical trial to compare two cholesterol
 
 ```{r}
 # TrialSize:
-TwoSampleMean.Equivalence(0.05, 0.2, 0.1, 1, 0.05, 0.01)
+TrialSize::TwoSampleMean.Equivalence(0.05, 0.2, 0.1, 1, 0.05, 0.01)
 
 # SampleSize4ClinicalTrials:
-ssc_meancomp(
+SampleSize4ClinicalTrials::ssc_meancomp(
   design = 4L,
   ratio = 1,
   alpha = 0.05,
@@ -73,8 +73,7 @@ Let's consider a standard standard two-sequence, two period crossover design for
 
 ```{r}
 # TrialSize:
-TwoSampleCrossOver.Equivalence(0.05, 0.2, 0.2, 0.25, -0.1)
-
+TrialSize::TwoSampleCrossOver.Equivalence(0.05, 0.2, 0.2, 0.25, -0.1)
 ```
 
 #### References {.unnumbered}

--- a/R/sample_s_superiority.qmd
+++ b/R/sample_s_superiority.qmd
@@ -49,17 +49,33 @@ Primarily, we will consider the case with the same SDs.
 A client is interested in conducting a clinical trial to compare two cholesterol lowering agents for treatment of hypercholesterolemic patients. The primary efficacy parameter is a low-density lipidprotein cholesterol (LDL-C). Suppose that a difference of 8% in the percent change of LDL-C is considered a clinically meaningful difference and that the standard deviation is assumed to be 15%. What sample size is required for a two-sided false positive rate of 5% and a power of 80%?
 
 ```{r}
-# samplesize:
-n.ttest(power = 0.8, alpha = 0.05, mean.diff = 8, sd1 = 15,
-        k = 1, design = "unpaired", fraction = "balanced", variance = "equal")
+samplesize::n.ttest(
+  power = 0.8,
+  alpha = 0.05,
+  mean.diff = 8,
+  sd1 = 15,
+  k = 1,
+  design = "unpaired",
+  fraction = "balanced",
+  variance = "equal"
+)
 
-#stats:
-power.t.test(delta=8, sd=15, sig.level=0.05, power=0.8, 
-             type="two.sample", alternative="two.sided")
+stats::power.t.test(
+  delta = 8,
+  sd = 15,
+  sig.level = 0.05,
+  power = 0.8,
+  type = "two.sample",
+  alternative = "two.sided"
+)
 
-#pwr:
-pwr.t.test(d = 8/15, sig.level = 0.05, power = 0.80, 
-           type = "two.sample", alternative = "two.sided")
+pwr::pwr.t.test(
+  d = 8 / 15,
+  sig.level = 0.05,
+  power = 0.80,
+  type = "two.sample",
+  alternative = "two.sided"
+)
 
 ```
 
@@ -76,17 +92,32 @@ We wish to run an AB/BA single dose crossover to compare two brochodilators. The
 (After recalculating: $$32 * \sqrt{2} = 45$$)
 
 ```{r}
-# samplesize:
-n.ttest(power = 0.8, alpha = 0.05, mean.diff = 30, sd1 = 45,
-        k = 1, design = "paired", fraction = "balanced")
+samplesize::n.ttest(
+  power = 0.8,
+  alpha = 0.05,
+  mean.diff = 30,
+  sd1 = 45,
+  k = 1,
+  design = "paired",
+  fraction = "balanced"
+)
 
-#stats:
-power.t.test(delta=30, sd=45, sig.level=0.05, power=0.8, 
-             type="one.sample", alternative="two.sided")
+stats::power.t.test(
+  delta = 30,
+  sd = 45,
+  sig.level = 0.05,
+  power = 0.8,
+  type = "one.sample",
+  alternative = "two.sided"
+)
 
-#pwr:
-pwr.t.test(d = 30/45, sig.level = 0.05, power = 0.80, 
-           type = "one.sample", alternative = "two.sided")
+pwr::pwr.t.test(
+  d = 30 / 45,
+  sig.level = 0.05,
+  power = 0.80,
+  type = "one.sample",
+  alternative = "two.sided"
+)
 
 ```
 

--- a/R/sample_s_test_of_trends.qmd
+++ b/R/sample_s_test_of_trends.qmd
@@ -31,15 +31,15 @@ Initially, we need to compute probabilities by defining the logit trend model (u
 
 ```{r}
 # logit function of trend to compute probabilities
-logit_trend <- function(p0, slope, xvec){
-    logit0 <- log(p0/(1-p0))
-    logit_seq <- logit0 + (xvec - xvec[1]) * slope
-    pvec <- 1/(1+exp(-logit_seq))
-    pvec
+logit_trend <- function(p0, slope, xvec) {
+  logit0 <- log(p0 / (1 - p0))
+  logit_seq <- logit0 + (xvec - xvec[1]) * slope
+  pvec <- 1 / (1 + exp(-logit_seq))
+  pvec
 }
 
 # vector of probabilities (from the logit model):
-p0 <- logit_trend(0.001, slope=0.5, x=c(1,2,4,8,16))
+p0 <- logit_trend(0.001, slope = 0.5, x = c(1, 2, 4, 8, 16))
 
 # or simply (based on the study design table):
 p0 <- c(0.001, 0.016, 0.0045, 0.0321, 0.6441)
@@ -49,12 +49,14 @@ p0 <- c(0.001, 0.016, 0.0045, 0.0321, 0.6441)
 Now, function power.CA.test can be used:
 
 ```{r}
-power.CA.test(N = 37, 
-              pvec=p0, 
-              n.prop = c(10,10,10,5,2), 
-              scores = c(1,2,4,8,16),
-              alternative = "greater",
-              sig.level=0.025)
+multiCA::power.CA.test(
+  N = 37,
+  pvec = p0,
+  n.prop = c(10, 10, 10, 5, 2),
+  scores = c(1, 2, 4, 8, 16),
+  alternative = "greater",
+  sig.level = 0.025
+)
 
 ```
 
@@ -65,11 +67,13 @@ Note: We can obtain the same results using **alternative = "two.sided"** and **s
 Function power.multiCA.test is designed to calculate power of detecting trend in a categorical (multinomial) outcome. It does work as well in the special case of a binary outcome. However, the computation uses an approximation that is difficult to avoid for the multinomial setting but is not strictly necessary with the binary setting -- as a result power may slightly biased away from 50%. Additionally, only two-sided power is implemented there, but we can still use it knowing that 5% is the two-sided significance level corresponding to the one-sided test with 2.5% significance level.
 
 ```{r}
-power.multiCA.test(N=37, 
-                   pmatrix=rbind(p0, 1-p0),  
-                   scores = c(1,2,4,8,16), 
-                   n.prop = c(10,10,10,5,2),
-                   sig.level=0.05)
+multiCA::power.multiCA.test(
+  N = 37,
+  pmatrix = rbind(p0, 1 - p0),
+  scores = c(1, 2, 4, 8, 16),
+  n.prop = c(10, 10, 10, 5, 2),
+  sig.level = 0.05
+)
 
 ```
 
@@ -92,14 +96,16 @@ R code:
 
 ```{r}
 # only using the power.CA.test and previously defined logit model:
-p1 <- logit_trend(0.0001, slope=0.049, x=c(0, 5, 30, 75))
+p1 <- logit_trend(0.0001, slope = 0.049, x = c(0, 5, 30, 75))
 
-power.CA.test(N = 7960, 
-              pvec=p1, 
-              n.prop = c(2500, 3600, 1450, 410), 
-              scores = c(0, 5, 30, 75),
-              alternative = "greater",
-              sig.level=0.025)
+multiCA::power.CA.test(
+  N = 7960,
+  pvec = p1,
+  n.prop = c(2500, 3600, 1450, 410),
+  scores = c(0, 5, 30, 75),
+  alternative = "greater",
+  sig.level = 0.025
+)
 ```
 
 Asymptotic power is equal to 72%.
@@ -120,11 +126,13 @@ What is the required sample size to achieve the power of 80% with the significan
 R code:
 
 ```{r}
-power.CA.test(power=0.8, 
-              pvec=c(0.10, 0.13, 0.16, 0.19, 0.22), 
-              scores = c(0, 1, 2, 4, 8),
-              alternative = "greater", 
-              sig.level=0.05)
+multiCA::power.CA.test(
+  power = 0.8,
+  pvec = c(0.10, 0.13, 0.16, 0.19, 0.22),
+  scores = c(0, 1, 2, 4, 8),
+  alternative = "greater",
+  sig.level = 0.05
+)
 ```
 
 Sample size N=527 subjects is required to achieve asymptotic power of 80%. That is the total sample size, including all the treatment arms/groups.

--- a/R/sample_size_average_bioequivalence.qmd
+++ b/R/sample_size_average_bioequivalence.qmd
@@ -23,7 +23,7 @@ library(purrr)
 `sampleN.TOST()` function can calculate sample size for different designs:
 
 ```{r}
-kable(known.designs())
+kable(PowerTOST::known.designs())
 ```
 
 Basic usage: we should specify `targetpower` (power to achieve at least, e.g. 0.8 or 0.9), `theta0` (T/R ratio if `logscale = TRUE` which is convenient default value) and `cv` (coefficient of variation given as ratio if `logscale = TRUE`).

--- a/R/sample_size_average_bioequivalence.qmd
+++ b/R/sample_size_average_bioequivalence.qmd
@@ -11,7 +11,6 @@ The most unambiguous requirements are mentioned in [FDA Guidance for Industry. S
 Appropriate method is described in `Diletti D, Hauschke D, Steinijans VW. Sample Size Determination for Bioequivalence Assessment by Means of Confidence Intervals. Int J Clin Pharmacol Ther Toxicol. 1991;29(1):1–8` and implemented in R package [PowerTOST](https://cran.r-project.org/web/packages/PowerTOST/index.html) with one clarification: it is simulation-based (iterative) procedure rather than simple calculation by formula.
 
 ```{r}
-#renv::install("PowerTOST")
 library(PowerTOST)
 library(knitr)
 library(data.table)
@@ -31,20 +30,20 @@ Basic usage: we should specify `targetpower` (power to achieve at least, e.g. 0.
 
 ```{r}
 # 2x2x2
-sampleN.TOST(
-  targetpower = 0.8, 
-  theta0 = 0.95, 
-  CV = 0.3, 
+PowerTOST::sampleN.TOST(
+  targetpower = 0.8,
+  theta0 = 0.95,
+  CV = 0.3,
   design = "2x2x2"
 )
 ```
 
 ```{r}
 # 2x2x4
-sampleN.TOST(
-  targetpower = 0.9, 
-  theta0 = 0.98, 
-  CV = 0.24, 
+PowerTOST::sampleN.TOST(
+  targetpower = 0.9,
+  theta0 = 0.98,
+  CV = 0.24,
   design = "2x2x4"
 )
 ```
@@ -66,9 +65,9 @@ theta0 <- 1 - 0.05
 CV <- c(0.15, 0.23, 0.3, 0.5)
 design <- c("2x2x2", "2x2x4")
 
-dt <- CJ(CV, targetpower, design, theta0)
+dt <- data.table::CJ(CV, targetpower, design, theta0)
 
-sample_size <- purrr::pmap(dt, sampleN.TOST, print = FALSE)
+sample_size <- purrr::pmap(dt, PowerTOST::sampleN.TOST, print = FALSE)
 kable(rbindlist(sample_size))
 ```
 
@@ -82,7 +81,7 @@ Conclusion: we can trust `sampleN.TOST()`; for CV less or equal 0.30 with power 
 CV can be calculated from CI boundaries and sample size if only these values are available:
 
 ```{r}
-CVfromCI(lower = 0.95, upper = 1.11, n = 38)
+PowerTOST::CVfromCI(lower = 0.95, upper = 1.11, n = 38)
 ```
 
 
@@ -90,4 +89,5 @@ CVfromCI(lower = 0.95, upper = 1.11, n = 38)
 ```{r}
 sessionInfo()
 ```
+
 :::

--- a/R/sample_size_non-inferiority.qmd
+++ b/R/sample_size_non-inferiority.qmd
@@ -13,18 +13,15 @@ This example is a sample size calculation for the following hypotheses: $H_0:\mu
 
 A client is interested in conducting a clinical trial to compare two cholesterol lowering agents for treatment of hypercholesterolemic patients through a parallel design. The primary efficacy parameter is a low-density lipidprotein cholesterol (LDL-C). We will consider the situation where the intended trial is for testing noninferiority. For establishing it, suppose the true mean difference is 0 and the noninferiority margin is chosen to be -0.05 (-5%). Assuming SD = 0.1, how many patients are required for an 80% power and an overall significance level of 5%?
 
-
 ```{r}
-getDesignInverseNormal(kMax = 1, alpha = 0.05) |>
-    getSampleSizeMeans(thetaH0 = -0.05, 
-                       alternative = 0,
-        stDev = 0.1,
-        allocationRatioPlanned = 1) |>
-    summary() 
+rpact::getDesignInverseNormal(kMax = 1, alpha = 0.05) |>
+  rpact::getSampleSizeMeans(
+    thetaH0 = -0.05,
+    alternative = 0,
+    stDev = 0.1,
+    allocationRatioPlanned = 1
+  ) |>
+  summary()
 ```
 
 Here the recommended sample size is 100.3, so we will need to round up to 51 subjects per arm. 
-
-
-
-

--- a/R/summary_skew_kurt.qmd
+++ b/R/summary_skew_kurt.qmd
@@ -8,7 +8,7 @@ output: html_document
 #| include: false
 knitr::opts_chunk$set(echo = TRUE)
 library(tibble)
- library(e1071)
+library(e1071)
 ```
 
 # **Skewness and Kurtosis in R**
@@ -79,13 +79,12 @@ All three skewness measures are unbiased under normality. The three methods are 
 #| message: false
 #| warning: false
 
-
 type1 <- e1071::skewness(dat$points, type = 1)
 stringr::str_glue("Skewness - Type 1: {type1}")
-  
+
 type2 <- e1071::skewness(dat$points, type = 2)
 stringr::str_glue("Skewness - Type 2: {type2}")
-  
+
 type3 <- e1071::skewness(dat$points, type = 3)
 stringr::str_glue("Skewness - Type 3: {type3}")
 ```
@@ -116,15 +115,14 @@ Only $G_2$ (corresponding to type 2) is unbiased under normality. The three meth
 #| message: false
 #| warning: false
 
-
-  # Kurtosis - Type 1
+# Kurtosis - Type 1
 type1 <- e1071::kurtosis(dat$points, type = 1)
 stringr::str_glue("Kurtosis - Type 1: {type1}")
-  
+
 # Kurtosis - Type 2
 type2 <- e1071::kurtosis(dat$points, type = 2)
 stringr::str_glue("Kurtosis - Type 2: {type2}")
-  
+
 # Kurtosis - Type 3
 type3 <- e1071::kurtosis(dat$points, type = 3)
 stringr::str_glue("Kurtosis - Type 3: {type3}")
@@ -142,15 +140,13 @@ The **moments** package is a well-known package with a variety of statistical fu
 #| message: false
 #| warning: false
 
-  library(moments)
+library(moments)
 
-  # Skewness - Type 1
-  moments::skewness(dat$points)
-  # [1] 0.9054442
-  
-  # Kurtosis - Pearson's measure
-  moments::kurtosis(dat$points)
-  # [1] 2.416659
+# Skewness - Type 1
+moments::skewness(dat$points)
+
+# Kurtosis - Pearson's measure
+moments::kurtosis(dat$points)
 
 ```
 
@@ -166,11 +162,10 @@ The **procs** package `proc_means()` function was written specifically to match 
 #| message: false
 #| warning: false
 
-  library(procs)
+library(procs)
 
-  # Skewness and Kurtosis - Type 2 
-  proc_means(dat, var = points,
-             stats = v(skew, kurt))
+# Skewness and Kurtosis - Type 2
+procs::proc_means(dat, var = points, stats = v(skew, kurt))
 
 ```
 
@@ -193,15 +188,13 @@ The **sasLM** package was also written specifically to match SAS. The `Skewness(
 #| message: false
 #| warning: false
 
-  library(sasLM)
+library(sasLM)
 
-  # Skewness - Type 2
-  Skewness(dat$points)
-  # [1] 1.009318
-  
-  # Kurtosis - Type 2
-  Kurtosis(dat$points)
-  # [1] -0.2991564
+# Skewness - Type 2
+sasLM::Skewness(dat$points)
+
+# Kurtosis - Type 2
+sasLM::Kurtosis(dat$points)
 
 ```
 
@@ -211,10 +204,14 @@ The **sasLM** package was also written specifically to match SAS. The `Skewness(
 ```{r}
 #| echo: false
 
-# List all the packages needed 
+# List all the packages needed
 si <- sessioninfo::session_info(c(
-  "e1071","procs","sasLM","moments"
+  "e1071",
+  "procs",
+  "sasLM",
+  "moments"
 ))
 si
 ```
+
 :::

--- a/R/survey-stats-summary.qmd
+++ b/R/survey-stats-summary.qmd
@@ -27,7 +27,8 @@ library(survey)
 
 data("api")
 
-head(apisrs) |> gt::gt()
+head(apisrs) |>
+  gt::gt()
 ```
 
 ## Mean
@@ -35,18 +36,18 @@ head(apisrs) |> gt::gt()
 If we want to calculate a mean of a variable in a dataset which has been obtained from a **s**imple **r**andom **s**ample such as `apisrs`, in R we can create a design object using the `survey::svydesign` function (specifying that there is no PSU using `id = ~1` and the finite population correction using `fpc=~fpc`).
 
 ```{r}
-srs_design <- svydesign(id = ~1, fpc = ~fpc, data = apisrs)
+srs_design <- survey::svydesign(id = ~1, fpc = ~fpc, data = apisrs)
 ```
 
 This design object stores all metadata about the sample alongside the data, and is used by all subsequent functions in the `{survey}` package. To calculate the mean, standard error, and confidence intervals of the `growth` variable, we can use the `survey::svymean` and `confint` functions:
 
 ```{r}
 # Calculate mean and SE of growth. The standard error will be corrected by the finite population correction specified in the design
-srs_means <- svymean(~growth, srs_design)
+srs_means <- survey::svymean(~growth, srs_design)
 
 srs_means
 # Use degf() to get the degrees of freedom
-confint(srs_means, df=degf(srs_design))
+confint(srs_means, df = survey::degf(srs_design))
 ```
 
 Note that to obtain correct results, we had to specify the degrees of freedom using the design object.
@@ -56,7 +57,7 @@ Note that to obtain correct results, we had to specify the degrees of freedom us
 Calculating population totals can be done using the `survey::svytotal` function in R.
 
 ```{r}
-svytotal(~growth, srs_design)
+survey::svytotal(~growth, srs_design)
 ```
 
 ## Ratios
@@ -64,17 +65,17 @@ svytotal(~growth, srs_design)
 To perform ratio analysis for means or proportions of analysis variables in R, we can `survey::svyratio`, here requesting that we do not `separate` the ratio estimation per Strata as this design is not stratified.
 
 ```{r}
-svy_ratio <- svyratio(
+svy_ratio <- survey::svyratio(
   ~api00,
   ~api99,
   srs_design,
-  se=TRUE,
-  df=degf(srs_design),
-  separate=FALSE
+  se = TRUE,
+  df = survey::degf(srs_design),
+  separate = FALSE
 )
 
 svy_ratio
-confint(svy_ratio, df=degf(srs_design))
+confint(svy_ratio, df = survey::degf(srs_design))
 ```
 
 ## Proportions
@@ -82,10 +83,10 @@ confint(svy_ratio, df=degf(srs_design))
 To calculate a proportion in R, we use the `svymean` function on a factor or character column:
 
 ```{r}
-props <- svymean(~sch.wide, srs_design)
+props <- survey::svymean(~sch.wide, srs_design)
 
 props
-confint(props, df=degf(srs_design))
+confint(props, df = survey::degf(srs_design))
 ```
 
 For proportions close to 0, it can be that `survey::svyciprop` is more accurate at producing confidence intervals than `confint`.
@@ -95,12 +96,12 @@ For proportions close to 0, it can be that `survey::svyciprop` is more accurate 
 To calculate quantiles in R, we can use the `survey::svyquantile` function. Note that this function was reworked in version 4.1 of `{survey}`, and prior to this had different arguments and results. The current version of `svyquantile` has an `qrule` which is similar to the `type` argument in `quantile`, and can be used to change how the quantiles are calculated. For more information, see `vignette("qrule", package="survey")`.
 
 ```{r}
-svyquantile(
+survey::svyquantile(
   ~growth,
   srs_design,
   quantiles = c(0.025, 0.5, 0.975),
-  ci=TRUE,
-  se=TRUE
+  ci = TRUE,
+  se = TRUE
 )
 ```
 
@@ -112,35 +113,43 @@ Much of the previous examples and notes still stand for more complex survey desi
 #| message: false
 data("nhanes")
 
-head(nhanes) |> gt::gt()
+head(nhanes) |>
+  gt::gt()
 ```
 
 To produce means and standard quartiles for this sample, taking account of sample design, we can use the following:
 
 ```{r}
-nhanes_design <- svydesign(
+nhanes_design <- survey::svydesign(
   data = nhanes,
   id = ~SDMVPSU, # Specify the PSU/cluster column
-  strata = ~SDMVSTRA,  # The stratification column
-  weights = ~WTMEC2YR,  # The weighting column
-  nest = TRUE  # Allows for PSUs with the same name nested within different strata
+  strata = ~SDMVSTRA, # The stratification column
+  weights = ~WTMEC2YR, # The weighting column
+  nest = TRUE # Allows for PSUs with the same name nested within different strata
 )
 
-svymean(~HI_CHOL, nhanes_design, na.rm=TRUE)
+survey::svymean(~HI_CHOL, nhanes_design, na.rm = TRUE)
 
-svyquantile(
+survey::svyquantile(
   ~HI_CHOL,
   nhanes_design,
-  quantiles=c(0.25, 0.5, 0.75),
-  na.rm=TRUE,
-  ci=TRUE
+  quantiles = c(0.25, 0.5, 0.75),
+  na.rm = TRUE,
+  ci = TRUE
 )
 ```
 
 In R, we can perform domain estimations of different sub-populations by passing our required survey function to the `svyby` function. `svyby` can also take additional options to pass to the function, for example here we pass `na.rm=TRUE` and `deff=TRUE` to `svymean`:
 
 ```{r}
-svyby(~HI_CHOL, ~race, nhanes_design, svymean, na.rm=TRUE, deff=TRUE)
+survey::svyby(
+  ~HI_CHOL,
+  ~race,
+  nhanes_design,
+  svymean,
+  na.rm = TRUE,
+  deff = TRUE
+)
 ```
 
 ::: {.callout-note collapse="true" title="Session Info"}
@@ -149,4 +158,5 @@ svyby(~HI_CHOL, ~race, nhanes_design, svymean, na.rm=TRUE, deff=TRUE)
 si <- sessioninfo::session_info("survey", dependencies = FALSE)
 si
 ```
+
 :::

--- a/R/survival.qmd
+++ b/R/survival.qmd
@@ -32,7 +32,7 @@ Below is a standard mock-up for survival analysis in clinical trials.
 #| echo: false
 #| fig-align: center
 #| out-width: 75%
-knitr::include_graphics("../images/survival/layout.png")   
+knitr::include_graphics("../images/survival/layout.png")
 ```
 
 ## Example Data
@@ -60,9 +60,11 @@ library(broom)
 library(knitr)
 knitr::opts_chunk$set(echo = TRUE)
 
-dat <- read_sas(file.path("../data/whas500.sas7bdat")) %>%
-  mutate(LENFOLY = round(LENFOL/365.25, 2), ## change follow-up days to years for better visualization
-         AFB = factor(AFB, levels = c(1, 0))) ## change AFB order to use "Yes" as the reference group to be consistent with SAS
+dat <- haven::read_sas(file.path("../data/whas500.sas7bdat")) |>
+  mutate(
+    LENFOLY = round(LENFOL / 365.25, 2), ## change follow-up days to years for better visualization
+    AFB = factor(AFB, levels = c(1, 0))
+  ) ## change AFB order to use "Yes" as the reference group to be consistent with SAS
 
 ```
 
@@ -75,13 +77,13 @@ The KM estimators are from `survival::survfit` function, the log-rank test uses 
 ### KM estimators
 
 ```{r}
-fit.km <- survfit(Surv(LENFOLY, FSTAT) ~ AFB, data = dat)
+fit.km <- survival::survfit(survival::Surv(LENFOLY, FSTAT) ~ AFB, data = dat)
 
 ## quantile estimates
-quantile(fit.km, probs = c(0.25, 0.5, 0.75)) 
+quantile(fit.km, probs = c(0.25, 0.5, 0.75))
 
 ## landmark estimates at 1, 3, 5-year
-summary(fit.km, times = c(1, 3, 5)) 
+summary(fit.km, times = c(1, 3, 5))
 
 ```
 
@@ -94,9 +96,9 @@ survminer::surv_pvalue(fit.km, data = dat)
 ### Cox PH model
 
 ```{r}
-fit.cox <- coxph(Surv(LENFOLY, FSTAT) ~ AFB, data = dat)
-fit.cox %>% 
-  tidy(exponentiate = TRUE, conf.int = TRUE, conf.level = 0.95) %>%
+fit.cox <- survival::coxph(survival::Surv(LENFOLY, FSTAT) ~ AFB, data = dat)
+fit.cox |>
+  tidy(exponentiate = TRUE, conf.int = TRUE, conf.level = 0.95) |>
   select(term, estimate, conf.low, conf.high)
 ```
 
@@ -107,7 +109,10 @@ In a stratified model, the Kaplan-Meier estimators remain the same as those in t
 ### Stratified Log-rank test
 
 ```{r}
-fit.km.str <- survfit(Surv(LENFOLY, FSTAT) ~ AFB + strata(GENDER), data = dat)
+fit.km.str <- survival::survfit(
+  survival::Surv(LENFOLY, FSTAT) ~ AFB + survival::strata(GENDER),
+  data = dat
+)
 
 survminer::surv_pvalue(fit.km.str, data = dat)
 ```
@@ -115,8 +120,11 @@ survminer::surv_pvalue(fit.km.str, data = dat)
 ### Stratified Cox PH model
 
 ```{r}
-fit.cox.str <- coxph(Surv(LENFOLY, FSTAT) ~ AFB + strata(GENDER), data = dat)
-fit.cox.str %>% 
-  tidy(exponentiate = TRUE, conf.int = TRUE, conf.level = 0.95) %>%
+fit.cox.str <- survival::coxph(
+  survival::Surv(LENFOLY, FSTAT) ~ AFB + survival::strata(GENDER),
+  data = dat
+)
+fit.cox.str |>
+  tidy(exponentiate = TRUE, conf.int = TRUE, conf.level = 0.95) |>
   select(term, estimate, conf.low, conf.high)
 ```

--- a/R/survival_cif.qmd
+++ b/R/survival_cif.qmd
@@ -7,6 +7,15 @@ title: "Estimating Cumulative Incidence Functions Using R"
 In this document we present how to estimate the cumulative incidence function (CIF) in R. We focus on the competing risks model where each subject experiences only one out of *k* possible events as depicted in the figure below.
 
 ```{r}
+#| message: false
+#| warning: false
+library(ggsurvfit)
+library(survival)
+library(tidycmprsk)
+library(tidyverse)
+```
+
+```{r}
 #| echo: false
 #| fig-align: center
 #| out-width: 25%
@@ -45,16 +54,18 @@ The bone marrow transplant (BTM) dataset as presented by Guo & So (2018) is used
 #| label: readdata
 #| message: false
 #| warning: false
-require(dplyr)
-bmt <- haven::read_sas(file.path("../data/bmt.sas7bdat")) %>%
+bmt <- haven::read_sas(file.path("../data/bmt.sas7bdat")) |>
   mutate(
-    Group = factor(Group, 
-                   levels = c(1, 2, 3), 
-                   labels = c('ALL', 'AML-Low Risk', 'AML-High Risk')
+    Group = factor(
+      Group,
+      levels = c(1, 2, 3),
+      labels = c('ALL', 'AML-Low Risk', 'AML-High Risk')
     ),
-    Status = factor(Status,
-                    levels = c(0, 1, 2),
-                    labels = c('Censored', 'Relapse', 'Death')),
+    Status = factor(
+      Status,
+      levels = c(0, 1, 2),
+      labels = c('Censored', 'Relapse', 'Death')
+    ),
     TYears = T / 365.25,
     ID = row_number()
   )
@@ -72,10 +83,7 @@ The `tidycmprsk::cuminc()` function requires a `Surv` object. Therefore, the fir
 #| label: cr.est
 #| message: false
 #| warning: false
-require(survival)
-require(tidycmprsk)
-require(tidyverse)
-cif.1 <- cuminc(Surv(TYears, Status) ~ Group, data = bmt) 
+cif.1 <- tidycmprsk::cuminc(Surv(TYears, Status) ~ Group, data = bmt)
 ```
 
 Gray's test statistics and p-value:
@@ -85,12 +93,12 @@ Gray's test statistics and p-value:
 #| message: false
 #| warning: false
 knitr::kable(
-  glance(cif.1) %>% 
-  pivot_longer(
-    everything(),
-    names_to = c(".value", "outcome_id"),
-    names_pattern = "(.*)_(.*)"
-  )
+  glance(cif.1) |>
+    pivot_longer(
+      everything(),
+      names_to = c(".value", "outcome_id"),
+      names_pattern = "(.*)_(.*)"
+    )
 )
 ```
 
@@ -101,13 +109,14 @@ CIF estimates for time to relapse at selected timepoints for 'AML-Low Risk' pati
 #| message: false
 #| warning: false
 knitr::kable(
-  cif.1 %>% 
-  tidy(times = c(0.5, 1, 1.5, 2, 3)) %>%
-  select(time, outcome, strata, estimate, std.error, conf.low, conf.high) %>% 
-  filter(outcome == 'Relapse' & strata == 'AML-Low Risk') %>%
-  mutate(time = as.character(time),
-         across(where(is.numeric), ~ num(., digits = 4))
-  )
+  cif.1 |>
+    tidy(times = c(0.5, 1, 1.5, 2, 3)) |>
+    select(time, outcome, strata, estimate, std.error, conf.low, conf.high) |>
+    filter(outcome == 'Relapse' & strata == 'AML-Low Risk') |>
+    mutate(
+      time = as.character(time),
+      across(where(is.numeric), ~ num(., digits = 4))
+    )
 )
 ```
 
@@ -123,16 +132,16 @@ Two points to note:
 #| label: cr.plot
 #| message: false
 #| warning: false
-require(ggsurvfit)
-cif.1 %>%
-  ggcuminc(outcome = 'Death') +
+cif.1 |>
+  ggsurvfit::ggcuminc(outcome = 'Death') +
   ## add_confidence_interval() +
-  add_risktable() +
+  ggsurvfit::add_risktable() +
   xlab('Time (years) to death')
-cif.1 %>%
-  ggcuminc(outcome = 'Relapse') +
+
+cif.1 |>
+  ggsurvfit::ggcuminc(outcome = 'Relapse') +
   ## add_confidence_interval() +
-  add_risktable() +
+  ggsurvfit::add_risktable() +
   xlab('Time (years) to relapse')
 ```
 
@@ -146,13 +155,14 @@ Using the bone marrow transplant example, the following code shows how to estima
 #| label: surv.est
 #| message: false
 #| warning: false
-cif.2 <- survfit(Surv(TYears, Status) ~ Group,
-                 data = bmt,
-                 se.fit = TRUE,
-                 conf.type = 'log-log', ## default is 'log'
-                 id = ID,
-                 robust = TRUE ## default for multi-state model
-                 )
+cif.2 <- survival::survfit(
+  survival::Surv(TYears, Status) ~ Group,
+  data = bmt,
+  se.fit = TRUE,
+  conf.type = 'log-log', ## default is 'log'
+  id = ID,
+  robust = TRUE ## default for multi-state model
+)
 ## summary(cif.2)
 ```
 
@@ -179,12 +189,14 @@ Certain options in SAS, e.g., the delta method for variance estimation or other 
 
 ::: {.callout-note collapse="true" title="Session Info"}
 ```{r}
- #| echo: false
- si <- sessioninfo::session_info(
- c("cmprsk", "tidycmprsk", "survival" ) #Vector of packages used 
- , dependencies = FALSE)
- si
+#| echo: false
+si <- sessioninfo::session_info(
+  c("cmprsk", "tidycmprsk", "survival"), #Vector of packages used
+  dependencies = FALSE
+)
+si
 ```
+
 :::
 
 ## Reference

--- a/R/survival_csh.qmd
+++ b/R/survival_csh.qmd
@@ -7,6 +7,13 @@ title: "Estimating and Testing Cause Specific Hazard Ratio Using R"
 In this document we present how to estimate and test cause specific hazard ratio for the probability of experiencing a certain event at a given time in a competing risks model in R. We focus on the basic model where each subject experiences only one out of *k* possible events as depicted in the figure below.
 
 ```{r}
+#| message: false
+#| warning: false
+library(survival)
+library(tidyverse)
+```
+
+```{r}
 #| echo: false
 #| fig-align: center
 #| out-width: 25%
@@ -39,16 +46,18 @@ The bone marrow transplant (BTM) dataset as presented by Guo & So (2018) is used
 #| label: readdata
 #| message: false
 #| warning: false
-require(dplyr)
 bmt <- haven::read_sas(file.path("../data/bmt.sas7bdat")) %>%
   mutate(
-    Group = factor(Group, 
-                   levels = c(1, 2, 3), 
-                   labels = c('ALL', 'AML-Low Risk', 'AML-High Risk')
+    Group = factor(
+      Group,
+      levels = c(1, 2, 3),
+      labels = c('ALL', 'AML-Low Risk', 'AML-High Risk')
     ),
-    Status = factor(Status,
-                    levels = c(0, 1, 2),
-                    labels = c('Censored', 'Relapse', 'Death')),
+    Status = factor(
+      Status,
+      levels = c(0, 1, 2),
+      labels = c('Censored', 'Relapse', 'Death')
+    ),
     TYears = T / 365.25,
     waitCat = (WaitTime > 200),
     ID = row_number()
@@ -65,13 +74,13 @@ Syntax-wise there are two ways to generate the estimates and related outputs usi
 #| label: cif.est
 #| message: false
 #| warning: false
-require(survival)
-csh.1 <- coxph(Surv(TYears, Status) ~ Group + strata(waitCat), 
-               data = bmt, 
-               id = ID, 
-               ties = 'breslow', ## default is 'efron'
-               robust = FALSE    ## default is TRUE
-               )
+csh.1 <- survival::coxph(
+  survival::Surv(TYears, Status) ~ Group + survival::strata(waitCat),
+  data = bmt,
+  id = ID,
+  ties = 'breslow', ## default is 'efron'
+  robust = FALSE ## default is TRUE
+)
 summary(csh.1)
 ```
 
@@ -82,12 +91,14 @@ Since both events (`Relapse` and `Death`) are model together, the global tests h
 ### Syntax 2: One event at a time
 
 ```{r}
-csh.2 <- coxph(Surv(TYears, Status == 'Relapse') ~ Group + strata(waitCat), 
-               data = bmt, 
-               id = ID, 
-               ties = 'breslow', ## default is 'efron'
-               robust = FALSE    ## default is TRUE
-               )
+csh.2 <- survival::coxph(
+  survival::Surv(TYears, Status == 'Relapse') ~
+    Group + survival::strata(waitCat),
+  data = bmt,
+  id = ID,
+  ties = 'breslow', ## default is 'efron'
+  robust = FALSE ## default is TRUE
+)
 summary(csh.2)
 ```
 
@@ -103,12 +114,14 @@ The results are identical to those labeled with `1:2` in the earlier outputs und
 
 ::: {.callout-note collapse="true" title="Session Info"}
 ```{r}
- #| echo: false
- si <- sessioninfo::session_info(
- c("cmprsk", "tidycmprsk", "survival" ) #Vector of packages used 
- , dependencies = FALSE)
- si
+#| echo: false
+si <- sessioninfo::session_info(
+  c("cmprsk", "tidycmprsk", "survival"), #Vector of packages used
+  dependencies = FALSE
+)
+si
 ```
+
 :::
 
 ## Reference

--- a/R/tipping_point.qmd
+++ b/R/tipping_point.qmd
@@ -80,7 +80,7 @@ dat <- antidepressant_data |>
     CHANGE
   ) |>
   dplyr::mutate(THERAPY = factor(THERAPY, levels = c("PLACEBO", "DRUG"))) |>
-  remove_labels()
+  labelled::remove_labels()
 
 gt(head(dat, n = 10))
 ```
@@ -118,13 +118,13 @@ dat_wide = dat |>
 
 dat_wide |>
   dplyr::select(starts_with("VISIT_")) |>
-  md.pattern(plot = TRUE, rotate.names = TRUE)
+  mice::md.pattern(plot = TRUE, rotate.names = TRUE)
 ```
 
 There is a single patient with an intermittent missing observation at visit 5, which is patient 3618. Special considerations need to be taken when applying delta adjustments to intermittent missing observations like this one (more on this later).
 
 ```{r}
-dat_expand <- expand_locf(
+dat_expand <- rbmi::expand_locf(
   dat,
   PATIENT = levels(dat$PATIENT),
   VISIT = levels(dat$VISIT),
@@ -160,7 +160,7 @@ dat_ice <- dat_ice[-which(dat_ice$PATIENT == 3618), ]
 ```{r}
 #| label: MAR_imputation_model
 #| include: false
-vars <- set_vars(
+vars <- rbmi::set_vars(
   outcome = "CHANGE",
   visit = "VISIT",
   subjid = "PATIENT",
@@ -168,12 +168,12 @@ vars <- set_vars(
   covariates = c("GENDER", "BASVAL*VISIT", "THERAPY*VISIT")
 )
 
-method <- method_bayes(
+method <- rbmi::method_bayes(
   n_samples = 500,
   control = control_bayes(warmup = 500, thin = 10)
 )
 
-drawObj <- draws(
+drawObj <- rbmi::draws(
   data = dat_expand,
   data_ice = dat_ice,
   vars = vars,
@@ -181,7 +181,7 @@ drawObj <- draws(
   quiet = TRUE
 )
 
-imputeObj <- impute(
+imputeObj <- rbmi::impute(
   draws = drawObj,
   references = NULL
 )
@@ -190,7 +190,7 @@ imputeObj <- impute(
 ```{r}
 #| label: MAR_analysis_model
 #| include: false
-vars_analyse <- set_vars(
+vars_analyse <- rbmi::set_vars(
   outcome = "CHANGE",
   visit = "VISIT",
   subjid = "PATIENT",
@@ -221,7 +221,7 @@ By default, `delta_template()` will set `delta` to 0 for all observations.
 
 ```{r}
 #| label: template_delta_0
-dat_delta_0 <- delta_template(imputations = imputeObj)
+dat_delta_0 <- rbmi::delta_template(imputations = imputeObj)
 
 dat_delta_0 |>
   dplyr::filter(PATIENT %in% c("1513", "1514")) |>
@@ -233,7 +233,7 @@ You can add the delta values to the outcome variable (CHANGE) of one of the impu
 
 ```{r}
 #| label: extract_imputed_dfs_on_which_to_apply_delta
-imputed_dfs = extract_imputed_dfs(imputeObj)
+imputed_dfs = rbmi::extract_imputed_dfs(imputeObj)
 MI_10 = imputed_dfs[[10]]
 MI_10$PATIENT2 = MI_10$PATIENT
 MI_10$PATIENT = dat_expand$PATIENT
@@ -261,7 +261,7 @@ You may have noticed that the `is_missing` and `is_post_ice` columns of the delt
 
 ```{r}
 #| label: template_delta_5_v1
-dat_delta_5_v1 <- delta_template(imputations = imputeObj) |>
+dat_delta_5_v1 <- rbmi::delta_template(imputations = imputeObj) |>
   mutate(delta = is_missing * 5)
 
 dat_delta_5_v1 |>
@@ -317,7 +317,7 @@ If you consider the `is_post_ice` column too, you can restrict the delta adjustm
 
 ```{r}
 #| label: template_delta_5_v2
-dat_delta_5_v2 <- delta_template(imputations = imputeObj) |>
+dat_delta_5_v2 <- rbmi::delta_template(imputations = imputeObj) |>
   mutate(delta = is_missing * is_post_ice * 5)
 
 dat_delta_5_v2 |>
@@ -348,7 +348,7 @@ Besides choosing which missing data to apply the delta adjustment to, you may al
 delta_control = 0
 delta_intervention = 5
 
-dat_delta_0_5 <- delta_template(imputations = imputeObj) |>
+dat_delta_0_5 <- rbmi::delta_template(imputations = imputeObj) |>
   mutate(
     delta_ctl = (THERAPY == "PLACEBO") * is_missing * delta_control,
     delta_int = (THERAPY == "DRUG") * is_missing * delta_intervention,
@@ -384,7 +384,7 @@ Here, we apply the delta adjustment of 5 to **all** imputed values of the outcom
 
 ```{r}
 #| label: MAR_analysis_model_with_delta_adjustment
-anaObj <- analyse(
+anaObj <- rbmi::analyse(
   imputations = imputeObj,
   fun = ancova,
   delta = dat_delta_0_5,
@@ -418,7 +418,7 @@ To cut down on computation time, you may want to increase the number of parallel
 
 ```{r}
 #| label: cluster_specification
-cl <- make_rbmi_cluster(ncores = 4)
+cl <- rbmi::make_rbmi_cluster(ncores = 4)
 ```
 
 ### Perform tipping point analysis
@@ -428,14 +428,14 @@ To enable a tipping point analysis within a single function, we create `perform_
 ```{r}
 #| label: function_tipping_point_analysis
 perform_tipp_analysis <- function(delta_control, delta_intervention, cl) {
-  dat_delta <- delta_template(imputeObj) |>
+  dat_delta <- rbmi::delta_template(imputeObj) |>
     mutate(
       delta_ctl = (THERAPY == "PLACEBO") * is_missing * delta_control,
       delta_int = (THERAPY == "DRUG") * is_missing * delta_intervention,
       delta = delta_ctl + delta_int
     )
 
-  anaObj <- analyse(
+  anaObj <- rbmi::analyse(
     imputations = imputeObj,
     fun = ancova,
     delta = dat_delta,
@@ -718,7 +718,7 @@ To program this, we first use the `delta` and `dlag` arguments of `delta_templat
 
 ```{r}
 #| label: template_delta_scaled
-dat_delta <- delta_template(
+dat_delta <- rbmi::delta_template(
   imputeObj,
   delta = c(2, 2, 2, 2),
   dlag = c(1, 1, 1, 1)
@@ -748,7 +748,7 @@ And lastly we use `dat_delta` to apply the desired delta offset to our analysis 
 ```{r}
 #| label: analysis_model_with_scaled_delta_adjustment
 #| output: false
-anaObj <- analyse(
+anaObj <- rbmi::analyse(
   imputations = imputeObj,
   fun = ancova,
   delta = dat_delta,
@@ -773,7 +773,7 @@ Adding a fixed delta in this way seems similar to what we explained in the *simp
 
 ```{r}
 #| label: delta_5_v1
-dat_delta_5_v1 <- delta_template(imputations = imputeObj) |>
+dat_delta_5_v1 <- rbmi::delta_template(imputations = imputeObj) |>
   mutate(delta = is_missing * 5)
 ```
 
@@ -781,7 +781,7 @@ And remember the second case where we added delta = 5 to all imputed `is_missing
 
 ```{r}
 #| label: delta_5_v2
-dat_delta_5_v2 <- delta_template(imputations = imputeObj) |>
+dat_delta_5_v2 <- rbmi::delta_template(imputations = imputeObj) |>
   mutate(delta = is_missing * is_post_ice * 5)
 ```
 
@@ -789,7 +789,7 @@ Similarly, we now set `delta = c(5, 5, 5, 5)` and `dlag = c(1, 0, 0, 0)`:
 
 ```{r}
 #| label: delta_5_v3
-dat_delta_5_v3 <- delta_template(
+dat_delta_5_v3 <- rbmi::delta_template(
   imputeObj,
   delta = c(5, 5, 5, 5),
   dlag = c(1, 0, 0, 0)

--- a/R/tipping_point.qmd
+++ b/R/tipping_point.qmd
@@ -11,12 +11,12 @@ knitr::opts_chunk$set(echo = TRUE)
 
 ## Setup
 
-### General libraries
-
 ```{r}
 #| label: general_libraries
 #| output: false
 #| warning: false
+
+# General libraries
 library(mice)
 library(dplyr)
 library(tidyr)
@@ -25,14 +25,8 @@ library(labelled)
 library(purrr)
 library(ggplot2)
 library(gridExtra)
-```
 
-### Methodology specific libraries
-
-```{r}
-#| label: methodology_specific_libraries
-#| output: false
-#| warning: false
+# Methodology specific libraries
 library(emmeans)
 library(mmrm)
 library(rstan)
@@ -74,20 +68,29 @@ The relevant endpoint for the antidepressant trial was assessed using the Hamilt
 #| label: data_exploration_1
 data("antidepressant_data")
 
-dat <- antidepressant_data %>%
-  dplyr::select(PATIENT, GENDER, THERAPY, RELDAYS, VISIT, BASVAL, HAMDTL17, CHANGE) %>%
-  dplyr::mutate(THERAPY = factor(THERAPY, levels = c("PLACEBO", "DRUG"))) %>%
+dat <- antidepressant_data |>
+  dplyr::select(
+    PATIENT,
+    GENDER,
+    THERAPY,
+    RELDAYS,
+    VISIT,
+    BASVAL,
+    HAMDTL17,
+    CHANGE
+  ) |>
+  dplyr::mutate(THERAPY = factor(THERAPY, levels = c("PLACEBO", "DRUG"))) |>
   remove_labels()
 
-gt(head(dat, n=10))
+gt(head(dat, n = 10))
 ```
 
 The number of patients per visit and treatment group are:
 
 ```{r}
 #| label: data_exploration_2
-dat %>%
-  group_by(VISIT, THERAPY) %>%
+dat |>
+  group_by(VISIT, THERAPY) |>
   dplyr::summarise(N = n())
 ```
 
@@ -95,26 +98,27 @@ The mean change from baseline of the HAMD17 endpoint per visit and treatment gro
 
 ```{r}
 #| label: data_exploration_3
-dat %>%
-  group_by(VISIT, THERAPY) %>%
-  dplyr::summarise(N = n(),
-                   MEAN = mean(CHANGE))
+dat |>
+  group_by(VISIT, THERAPY) |>
+  dplyr::summarise(N = n(), MEAN = mean(CHANGE))
 ```
 
 The missingness pattern is:
 
 ```{r}
 #| label: data_exploration_4
-dat_wide = dat %>%
-  dplyr::select(PATIENT, VISIT, CHANGE) %>%
-  pivot_wider(id_cols = PATIENT,
-              names_from = VISIT,
-              names_prefix = "VISIT_",
-              values_from = CHANGE)
+dat_wide = dat |>
+  dplyr::select(PATIENT, VISIT, CHANGE) |>
+  pivot_wider(
+    id_cols = PATIENT,
+    names_from = VISIT,
+    names_prefix = "VISIT_",
+    values_from = CHANGE
+  )
 
-dat_wide %>%
-  dplyr::select(starts_with("VISIT_")) %>%
-  md.pattern(plot=TRUE, rotate.names = TRUE)
+dat_wide |>
+  dplyr::select(starts_with("VISIT_")) |>
+  md.pattern(plot = TRUE, rotate.names = TRUE)
 ```
 
 There is a single patient with an intermittent missing observation at visit 5, which is patient 3618. Special considerations need to be taken when applying delta adjustments to intermittent missing observations like this one (more on this later).
@@ -129,7 +133,9 @@ dat_expand <- expand_locf(
   order = c("PATIENT", "VISIT")
 )
 
-gt(dat_expand %>% dplyr::filter(PATIENT == "3618"))
+dat_expand |>
+  dplyr::filter(PATIENT == "3618") |>
+  gt()
 ```
 
 ### Preparation
@@ -139,16 +145,16 @@ This tutorial will focus on delta adjustment and tipping point analysis. We assu
 ```{r}
 #| label: MAR_data
 #| include: false
-dat_ice <- dat_expand %>% 
-  arrange(PATIENT, VISIT) %>% 
-  filter(is.na(CHANGE)) %>% 
-  group_by(PATIENT) %>% 
-  slice(1) %>%
-  ungroup() %>% 
-  select(PATIENT, VISIT) %>% 
+dat_ice <- dat_expand |>
+  arrange(PATIENT, VISIT) |>
+  filter(is.na(CHANGE)) |>
+  group_by(PATIENT) |>
+  slice(1) |>
+  ungroup() |>
+  select(PATIENT, VISIT) |>
   mutate(strategy = "MAR")
 
-dat_ice <- dat_ice[-which(dat_ice$PATIENT == 3618),]
+dat_ice <- dat_ice[-which(dat_ice$PATIENT == 3618), ]
 ```
 
 ```{r}
@@ -177,7 +183,8 @@ drawObj <- draws(
 
 imputeObj <- impute(
   draws = drawObj,
-  references = NULL)
+  references = NULL
+)
 ```
 
 ```{r}
@@ -216,7 +223,10 @@ By default, `delta_template()` will set `delta` to 0 for all observations.
 #| label: template_delta_0
 dat_delta_0 <- delta_template(imputations = imputeObj)
 
-gt(dat_delta_0 %>% dplyr::filter(PATIENT %in% c("1513", "1514")) %>% head(8))
+dat_delta_0 |>
+  dplyr::filter(PATIENT %in% c("1513", "1514")) |>
+  head(8) |>
+  gt()
 ```
 
 You can add the delta values to the outcome variable (CHANGE) of one of the imputed datasets by using the `apply_delta()` function. Of course, nothing is changed here as delta = 0.
@@ -231,11 +241,19 @@ MI_10$PATIENT = dat_expand$PATIENT
 
 ```{r}
 #| label: apply_delta_0
-gt(MI_10 %>% dplyr::filter(PATIENT %in% c("1513", "1514")) %>% head(8))
+MI_10 |>
+  dplyr::filter(PATIENT %in% c("1513", "1514")) |>
+  head(8) |>
+  gt()
 
-rbmi:::apply_delta(MI_10, delta = dat_delta_0, group = c("PATIENT", "VISIT", "THERAPY"), outcome = "CHANGE") %>%
-  dplyr::filter(PATIENT %in% c("1513", "1514")) %>%
-  head(8) %>%
+rbmi:::apply_delta(
+  MI_10,
+  delta = dat_delta_0,
+  group = c("PATIENT", "VISIT", "THERAPY"),
+  outcome = "CHANGE"
+) |>
+  dplyr::filter(PATIENT %in% c("1513", "1514")) |>
+  head(8) |>
   gt()
 ```
 
@@ -243,19 +261,30 @@ You may have noticed that the `is_missing` and `is_post_ice` columns of the delt
 
 ```{r}
 #| label: template_delta_5_v1
-dat_delta_5_v1 <- delta_template(imputations = imputeObj) %>%
-    mutate(delta = is_missing * 5)
+dat_delta_5_v1 <- delta_template(imputations = imputeObj) |>
+  mutate(delta = is_missing * 5)
 
-gt(dat_delta_5_v1 %>% dplyr::filter(PATIENT %in% c("1513", "1514")) %>% head(8))
+dat_delta_5_v1 |>
+  dplyr::filter(PATIENT %in% c("1513", "1514")) |>
+  head(8) |>
+  gt()
 ```
 
 ```{r}
 #| label: apply_delta_5_v1
-gt(MI_10 %>% dplyr::filter(PATIENT %in% c("1513", "1514")) %>% head(8))
+MI_10 |>
+  dplyr::filter(PATIENT %in% c("1513", "1514")) |>
+  head(8) |>
+  gt()
 
-rbmi:::apply_delta(MI_10, delta = dat_delta_5_v1, group = c("PATIENT", "VISIT", "THERAPY"), outcome = "CHANGE") %>%
-  dplyr::filter(PATIENT %in% c("1513", "1514")) %>%
-  head(8) %>%
+rbmi:::apply_delta(
+  MI_10,
+  delta = dat_delta_5_v1,
+  group = c("PATIENT", "VISIT", "THERAPY"),
+  outcome = "CHANGE"
+) |>
+  dplyr::filter(PATIENT %in% c("1513", "1514")) |>
+  head(8) |>
   gt()
 ```
 
@@ -263,15 +292,24 @@ Importantly, if you multiply the `is_missing` column only, you apply the delta a
 
 ```{r}
 #| label: template_delta_5_v1_3618
-gt(dat_delta_5_v1 %>% dplyr::filter(PATIENT == "3618"))
+dat_delta_5_v1 |>
+  dplyr::filter(PATIENT == "3618") |>
+  gt()
 ```
 
 ```{r}
 #| label: apply_delta_5_v1_3618
-gt(MI_10 %>% dplyr::filter(PATIENT == "3618"))
+MI_10 |>
+  dplyr::filter(PATIENT == "3618") |>
+  gt()
 
-rbmi:::apply_delta(MI_10, delta = dat_delta_5_v1, group = c("PATIENT", "VISIT", "THERAPY"), outcome = "CHANGE") %>%
-  dplyr::filter(PATIENT == "3618") %>%
+rbmi:::apply_delta(
+  MI_10,
+  delta = dat_delta_5_v1,
+  group = c("PATIENT", "VISIT", "THERAPY"),
+  outcome = "CHANGE"
+) |>
+  dplyr::filter(PATIENT == "3618") |>
   gt()
 ```
 
@@ -279,18 +317,27 @@ If you consider the `is_post_ice` column too, you can restrict the delta adjustm
 
 ```{r}
 #| label: template_delta_5_v2
-dat_delta_5_v2 <- delta_template(imputations = imputeObj) %>%
-    mutate(delta = is_missing * is_post_ice * 5)
+dat_delta_5_v2 <- delta_template(imputations = imputeObj) |>
+  mutate(delta = is_missing * is_post_ice * 5)
 
-gt(dat_delta_5_v2 %>% dplyr::filter(PATIENT == "3618"))
+dat_delta_5_v2 |>
+  dplyr::filter(PATIENT == "3618") |>
+  gt()
 ```
 
 ```{r}
 #| label: apply_delta_5_v2
-gt(MI_10 %>% dplyr::filter(PATIENT == "3618"))
+MI_10 |>
+  dplyr::filter(PATIENT == "3618") |>
+  gt()
 
-rbmi:::apply_delta(MI_10, delta = dat_delta_5_v2, group = c("PATIENT", "VISIT", "THERAPY"), outcome = "CHANGE") %>%
-  dplyr::filter(PATIENT == "3618") %>%
+rbmi:::apply_delta(
+  MI_10,
+  delta = dat_delta_5_v2,
+  group = c("PATIENT", "VISIT", "THERAPY"),
+  outcome = "CHANGE"
+) |>
+  dplyr::filter(PATIENT == "3618") |>
   gt()
 ```
 
@@ -301,21 +348,29 @@ Besides choosing which missing data to apply the delta adjustment to, you may al
 delta_control = 0
 delta_intervention = 5
 
-dat_delta_0_5 <- delta_template(imputations = imputeObj) %>%
+dat_delta_0_5 <- delta_template(imputations = imputeObj) |>
   mutate(
     delta_ctl = (THERAPY == "PLACEBO") * is_missing * delta_control,
     delta_int = (THERAPY == "DRUG") * is_missing * delta_intervention,
     delta = delta_ctl + delta_int
-    )
+  )
 
-gt(dat_delta_0_5 %>% dplyr::filter(PATIENT %in% c("1513", "1514")) %>% head(8))
+dat_delta_0_5 |>
+  dplyr::filter(PATIENT %in% c("1513", "1514")) |>
+  head(8) |>
+  gt()
 ```
 
 ```{r}
 #| label: apply_stratified_delta
-rbmi:::apply_delta(MI_10, delta = dat_delta_0_5, group = c("PATIENT", "VISIT", "THERAPY"), outcome = "CHANGE") %>%
-  dplyr::filter(PATIENT %in% c("1513", "1514")) %>%
-  head(8) %>%
+rbmi:::apply_delta(
+  MI_10,
+  delta = dat_delta_0_5,
+  group = c("PATIENT", "VISIT", "THERAPY"),
+  outcome = "CHANGE"
+) |>
+  dplyr::filter(PATIENT %in% c("1513", "1514")) |>
+  head(8) |>
   gt()
 ```
 
@@ -330,18 +385,18 @@ Here, we apply the delta adjustment of 5 to **all** imputed values of the outcom
 ```{r}
 #| label: MAR_analysis_model_with_delta_adjustment
 anaObj <- analyse(
-    imputations = imputeObj,
-    fun = ancova,
-    delta = dat_delta_0_5,
-    vars = vars_analyse
+  imputations = imputeObj,
+  fun = ancova,
+  delta = dat_delta_0_5,
+  vars = vars_analyse
 )
 
 poolObj <- rbmi::pool(anaObj)
 
-poolObj %>%
-  data.frame() %>%
-  dplyr::filter(grepl("7", parameter)) %>%
-  gt()  
+poolObj |>
+  data.frame() |>
+  dplyr::filter(grepl("7", parameter)) |>
+  gt()
 ```
 
 ## Tipping point analysis: MAR approach
@@ -353,10 +408,10 @@ To perform a tipping point analysis under the MAR assumption, we must create a r
 ```{r}
 #| label: sequential_delta_specification_v1
 delta_df1 <- expand.grid(
-    delta_control = 0,
-    delta_intervention = seq(-5, 10, by = 1)
-    ) %>%
-    as_tibble()
+  delta_control = 0,
+  delta_intervention = seq(-5, 10, by = 1)
+) |>
+  as_tibble()
 ```
 
 To cut down on computation time, you may want to increase the number of parallel processes.
@@ -373,8 +428,7 @@ To enable a tipping point analysis within a single function, we create `perform_
 ```{r}
 #| label: function_tipping_point_analysis
 perform_tipp_analysis <- function(delta_control, delta_intervention, cl) {
-
-  dat_delta <- delta_template(imputeObj) %>%
+  dat_delta <- delta_template(imputeObj) |>
     mutate(
       delta_ctl = (THERAPY == "PLACEBO") * is_missing * delta_control,
       delta_int = (THERAPY == "DRUG") * is_missing * delta_intervention,
@@ -389,9 +443,9 @@ perform_tipp_analysis <- function(delta_control, delta_intervention, cl) {
     ncores = cl
   )
 
-  poolObj <- as.data.frame(pool(anaObj)) %>%
+  poolObj <- as.data.frame(pool(anaObj)) |>
     dplyr::filter(grepl("trt_7", parameter))
-  
+
   list(
     trt_7 = poolObj[["est"]],
     pval_7 = poolObj[["pval"]],
@@ -405,14 +459,19 @@ Now, let's apply this function to the antidepressant data as follows:
 
 ```{r}
 #| label: MAR_v1_tipping_point_analysis
-MAR_tipp_df1 <- delta_df1 %>%
+MAR_tipp_df1 <- delta_df1 |>
   mutate(
-    results_list = map2(delta_control, delta_intervention, perform_tipp_analysis, cl = cl),
+    results_list = map2(
+      delta_control,
+      delta_intervention,
+      perform_tipp_analysis,
+      cl = cl
+    ),
     trt_7 = map_dbl(results_list, "trt_7"),
     pval_7 = map_dbl(results_list, "pval_7"),
     lci_7 = map_dbl(results_list, "lci_7"),
     uci_7 = map_dbl(results_list, "uci_7")
-  ) %>%
+  ) |>
   select(-results_list)
 ```
 
@@ -420,8 +479,8 @@ The results of the tipping point analysis under MAR with p-value $\geq$ 5% are:
 
 ```{r}
 #| label: MAR_v1_non-significant_results
-MAR_tipp_df1 %>%
-  filter(pval_7 >= 0.05) %>%
+MAR_tipp_df1 |>
+  filter(pval_7 >= 0.05) |>
   gt()
 ```
 
@@ -429,8 +488,8 @@ The results of the tipping point analysis under MAR with p-value $<$ 5% are:
 
 ```{r}
 #| label: MAR_v1_significant_results
-MAR_tipp_df1 %>%
-  filter(pval_7 < 0.05) %>%
+MAR_tipp_df1 |>
+  filter(pval_7 < 0.05) |>
   gt()
 ```
 
@@ -438,23 +497,38 @@ We can derive an **exact** tipping point by linearly interpolating between the l
 
 ```{r}
 #| label: MAR_v1_tipping_point
-delta_tp <- approx(x = MAR_tipp_df1$pval_7, 
-                   y = MAR_tipp_df1$delta_intervention, 
-                   xout = 0.05)$y
+delta_tp <- approx(
+  x = MAR_tipp_df1$pval_7,
+  y = MAR_tipp_df1$delta_intervention,
+  xout = 0.05
+)$y
 
-trt_tp <- approx(x = MAR_tipp_df1$delta_intervention, 
-                 y = MAR_tipp_df1$trt_7,
-                 xout = delta_tp)$y
+trt_tp <- approx(
+  x = MAR_tipp_df1$delta_intervention,
+  y = MAR_tipp_df1$trt_7,
+  xout = delta_tp
+)$y
 
-lci_tp <- approx(x = MAR_tipp_df1$delta_intervention, 
-                 y = MAR_tipp_df1$lci_7,
-                 xout = delta_tp)$y
+lci_tp <- approx(
+  x = MAR_tipp_df1$delta_intervention,
+  y = MAR_tipp_df1$lci_7,
+  xout = delta_tp
+)$y
 
-uci_tp <- approx(x = MAR_tipp_df1$delta_intervention, 
-                 y = MAR_tipp_df1$uci_7,
-                 xout = delta_tp)$y
+uci_tp <- approx(
+  x = MAR_tipp_df1$delta_intervention,
+  y = MAR_tipp_df1$uci_7,
+  xout = delta_tp
+)$y
 
-data.frame(delta_control = 0, delta_intervention = delta_tp, trt_7 = trt_tp, pval_7 = 0.05, lci_7 = lci_tp, uci_7 = uci_tp) %>%
+data.frame(
+  delta_control = 0,
+  delta_intervention = delta_tp,
+  trt_7 = trt_tp,
+  pval_7 = 0.05,
+  lci_7 = lci_tp,
+  uci_7 = uci_tp
+) |>
   gt()
 ```
 
@@ -467,19 +541,22 @@ A nice visualization of this tipping point analysis for the MAR approach is (the
 MAR_est <- ggplot(MAR_tipp_df1, aes(delta_intervention, trt_7)) +
   geom_line() +
   geom_point() +
-  geom_ribbon(aes(delta_intervention, ymin = lci_7, ymax = uci_7), alpha = 0.25) +
+  geom_ribbon(
+    aes(delta_intervention, ymin = lci_7, ymax = uci_7),
+    alpha = 0.25
+  ) +
   geom_hline(yintercept = 0.0, linetype = 2) +
   geom_vline(xintercept = delta_tp, linetype = 2) +
   scale_x_continuous(breaks = seq(-6, 10, 2)) +
-  labs(x = "Delta (intervention)", y = "Treatment effect (95% CI)") 
-  
+  labs(x = "Delta (intervention)", y = "Treatment effect (95% CI)")
+
 MAR_pval <- ggplot(MAR_tipp_df1, aes(delta_intervention, pval_7)) +
   geom_line() +
   geom_point() +
   geom_hline(yintercept = 0.05, linetype = 2) +
   geom_vline(xintercept = delta_tp, linetype = 2) +
   scale_x_continuous(breaks = seq(-6, 10, 2)) +
-  labs(x = "Delta (intervention)", y = "P-value") 
+  labs(x = "Delta (intervention)", y = "P-value")
 
 grid.arrange(MAR_pval, MAR_est, nrow = 1)
 ```
@@ -493,27 +570,38 @@ Let's now create a sequence of delta's for the control group too, and carry out 
 ```{r}
 #| label: sequential_delta_specification_v2
 delta_df2 <- expand.grid(
-    delta_control = seq(-5, 10, by = 1),
-    delta_intervention = seq(-5, 10, by = 1)
-    ) %>%
-    as_tibble()
+  delta_control = seq(-5, 10, by = 1),
+  delta_intervention = seq(-5, 10, by = 1)
+) |>
+  as_tibble()
 ```
 
 ```{r}
 #| label: MAR_v2_tipping_point_analysis
-MAR_tipp_df2 <- delta_df2 %>%
+MAR_tipp_df2 <- delta_df2 |>
   mutate(
-    results_list = map2(delta_control, delta_intervention, perform_tipp_analysis, cl = cl),
+    results_list = map2(
+      delta_control,
+      delta_intervention,
+      perform_tipp_analysis,
+      cl = cl
+    ),
     trt_7 = map_dbl(results_list, "trt_7"),
     pval_7 = map_dbl(results_list, "pval_7")
-  ) %>%
-  select(-results_list) %>%
+  ) |>
+  select(-results_list) |>
   mutate(
     pval = cut(
       pval_7,
       c(0, 0.001, 0.01, 0.05, 0.2, 1),
       right = FALSE,
-      labels = c("<0.001", "0.001 - <0.01", "0.01 - <0.05", "0.05 - <0.20", ">= 0.20")
+      labels = c(
+        "<0.001",
+        "0.001 - <0.01",
+        "0.01 - <0.05",
+        "0.05 - <0.20",
+        ">= 0.20"
+      )
     )
   )
 ```
@@ -522,12 +610,17 @@ We can visualize the result of this tipping point analysis using a heatmap. Here
 
 ```{r}
 #| label: MAR_v2_tipping_point_visualization
-MAR_heat <- ggplot(MAR_tipp_df2, aes(delta_control, delta_intervention, fill = pval)) +
+MAR_heat <- ggplot(
+  MAR_tipp_df2,
+  aes(delta_control, delta_intervention, fill = pval)
+) +
   geom_raster() +
-  scale_fill_manual(values = c("darkgreen", "lightgreen", "lightyellow", "orange", "red")) +
+  scale_fill_manual(
+    values = c("darkgreen", "lightgreen", "lightyellow", "orange", "red")
+  ) +
   scale_x_continuous(breaks = seq(-5, 10, 1)) +
   scale_y_continuous(breaks = seq(-5, 10, 1)) +
-  labs(x = "Delta (control)", y = "Delta (intervention)", fill = "P-value") 
+  labs(x = "Delta (control)", y = "Delta (intervention)", fill = "P-value")
 MAR_heat
 ```
 
@@ -631,17 +724,23 @@ dat_delta <- delta_template(
   dlag = c(1, 1, 1, 1)
 )
 
-gt(dat_delta %>% dplyr::filter(PATIENT %in% c("1513", "1514")) %>% head(8))
+dat_delta |>
+  dplyr::filter(PATIENT %in% c("1513", "1514")) |>
+  head(8) |>
+  gt()
 ```
 
 Then, we use some metadata variables provided by `delta_template()` to manually reset the delta values for the control group back to 0.
 
 ```{r}
 #| label: stratified_delta_scaled
-dat_delta <- dat_delta %>%
-    mutate(delta = if_else(THERAPY == "PLACEBO", 0, delta))
+dat_delta <- dat_delta |>
+  mutate(delta = if_else(THERAPY == "PLACEBO", 0, delta))
 
-gt(dat_delta %>% dplyr::filter(PATIENT %in% c("1513", "1514")) %>% head(8))
+dat_delta |>
+  dplyr::filter(PATIENT %in% c("1513", "1514")) |>
+  head(8) |>
+  gt()
 ```
 
 And lastly we use `dat_delta` to apply the desired delta offset to our analysis model under the `delta` argument of the `analyse()` function.
@@ -650,10 +749,10 @@ And lastly we use `dat_delta` to apply the desired delta offset to our analysis 
 #| label: analysis_model_with_scaled_delta_adjustment
 #| output: false
 anaObj <- analyse(
-    imputations = imputeObj,
-    fun = ancova,
-    delta = dat_delta,
-    vars = vars_analyse
+  imputations = imputeObj,
+  fun = ancova,
+  delta = dat_delta,
+  vars = vars_analyse
 )
 
 poolObj <- rbmi::pool(anaObj)
@@ -674,16 +773,16 @@ Adding a fixed delta in this way seems similar to what we explained in the *simp
 
 ```{r}
 #| label: delta_5_v1
-dat_delta_5_v1 <- delta_template(imputations = imputeObj) %>%
-    mutate(delta = is_missing * 5)
+dat_delta_5_v1 <- delta_template(imputations = imputeObj) |>
+  mutate(delta = is_missing * 5)
 ```
 
 And remember the second case where we added delta = 5 to all imputed `is_missing` and `is_post_ice` values:
 
 ```{r}
 #| label: delta_5_v2
-dat_delta_5_v2 <- delta_template(imputations = imputeObj) %>%
-    mutate(delta = is_missing * is_post_ice * 5)
+dat_delta_5_v2 <- delta_template(imputations = imputeObj) |>
+  mutate(delta = is_missing * is_post_ice * 5)
 ```
 
 Similarly, we now set `delta = c(5, 5, 5, 5)` and `dlag = c(1, 0, 0, 0)`:
@@ -691,8 +790,8 @@ Similarly, we now set `delta = c(5, 5, 5, 5)` and `dlag = c(1, 0, 0, 0)`:
 ```{r}
 #| label: delta_5_v3
 dat_delta_5_v3 <- delta_template(
-  imputeObj, 
-  delta = c(5, 5, 5, 5), 
+  imputeObj,
+  delta = c(5, 5, 5, 5),
   dlag = c(1, 0, 0, 0)
 )
 ```
@@ -704,21 +803,38 @@ If we consider patient 3618 again, we see that its intermittent missing value at
 ```{r}
 #| label: delta_5_comparison
 # without delta adjustment
-gt(MI_10 %>% dplyr::filter(PATIENT == "3618"))
+MI_10 |>
+  dplyr::filter(PATIENT == "3618") |>
+  gt()
 
 # mutate delta = is_missing * 5
-rbmi:::apply_delta(MI_10, delta = dat_delta_5_v1, group = c("PATIENT", "VISIT", "THERAPY"), outcome = "CHANGE") %>%
-  dplyr::filter(PATIENT == 3618) %>%
+rbmi:::apply_delta(
+  MI_10,
+  delta = dat_delta_5_v1,
+  group = c("PATIENT", "VISIT", "THERAPY"),
+  outcome = "CHANGE"
+) |>
+  dplyr::filter(PATIENT == 3618) |>
   gt()
 
 # mutate delta = is_missing * is_post_ice * 5
-rbmi:::apply_delta(MI_10, delta = dat_delta_5_v2, group = c("PATIENT", "VISIT", "THERAPY"), outcome = "CHANGE") %>%
-  dplyr::filter(PATIENT == 3618) %>%
+rbmi:::apply_delta(
+  MI_10,
+  delta = dat_delta_5_v2,
+  group = c("PATIENT", "VISIT", "THERAPY"),
+  outcome = "CHANGE"
+) |>
+  dplyr::filter(PATIENT == 3618) |>
   gt()
 
 # delta = c(5, 5, 5, 5), dlag = c(1, 0, 0, 0)
-rbmi:::apply_delta(MI_10, delta = dat_delta_5_v3, group = c("PATIENT", "VISIT", "THERAPY"), outcome = "CHANGE") %>%
-  dplyr::filter(PATIENT == 3618) %>%
+rbmi:::apply_delta(
+  MI_10,
+  delta = dat_delta_5_v3,
+  group = c("PATIENT", "VISIT", "THERAPY"),
+  outcome = "CHANGE"
+) |>
+  dplyr::filter(PATIENT == 3618) |>
   gt()
 ```
 
@@ -746,4 +862,5 @@ One should be aware of this discrepancy when using the `rbmi` package for delta 
 si <- sessioninfo::session_info(c())
 si
 ```
+
 :::

--- a/R/tobit regression.qmd
+++ b/R/tobit regression.qmd
@@ -1,30 +1,23 @@
 ---
-title: "<R> <Tobit Regression>"
+title: "Tobit Regression"
 ---
 
 # Tobit regression
 
-## Libraries
-
-### General
 ```{r}
 #| output: false
 #| warning: false
+# General
 library(dplyr)
 library(gt)
 library(broom)
-```
 
-### Methodology specific
-```{r}
-#| output: false
-#| warning: false
+# Methodology specific
 library(emmeans)
 library(censReg)
 library(survival)
 library(VGAM)
 ```
-
 
 ## Tobit model
 
@@ -81,7 +74,6 @@ dat_used = tribble(
 gt(dat_used)
 ```
 
-
 ## Example Code using R
 
 The analysis will be based on a Tobit analysis of variance with $Y$, rounded to 1 decimal places, as dependent variable and study group as a fixed covariate. A normally distributed error term will be used. Values will be left censored at the value 8.0.
@@ -89,29 +81,31 @@ The analysis will be based on a Tobit analysis of variance with $Y$, rounded to 
 Several R functions and packages are presented.
 
 ### censReg
+
 The `censReg` function from the `censReg` package performs tobit models for left and right censored. The model is estimated by Maximum Likelihood (ML) assuming a Gaussian (normal) distribution of the error term. The maximization of the likelihood function is done by function `maxLik` of the `maxLik` package. The optimization method can be changed.
+
 ```{r}
 #| label: censReg
-res_censreg = censReg(Y ~ ARM, 
-                      left = 8.0, 
-                      data = dat_used)
+res_censreg = censReg::censReg(Y ~ ARM, left = 8.0, data = dat_used)
 summary(res_censreg)
 
 # Difference between groups (Wald CIs)
-round(res_censreg$estimate[2], 3) 
-round(stats::confint(res_censreg, level = 0.95)[2,], 3)
+round(res_censreg$estimate[2], 3)
+round(stats::confint(res_censreg, level = 0.95)[2, ], 3)
 ```
+
 The output provides an estimate of difference between groups A and B (B-A), namely 1.8225 (se=0.8061). The presented p-value is a two-sided p-value based on the Z-test. The output also provides an estimate for $log(\sigma) = 0.5491$. Wald based confidence intervals can be obtained by the `stats::confint` function.
-
-
 
 ### survreg
 Using the `survreg` function from the `survival` package a tobit model can be fit. For more information, refer to the [survival package](https://cran.r-project.org/web/packages/survival/index.html).
+
 ```{r}
 #| label: survreg
-res_survreg = survreg(Surv(Y, 1-CENS, type="left") ~ ARM,
-                      dist = "gaussian",
-                      data = dat_used)
+res_survreg = survival::survreg(
+  survival::Surv(Y, 1 - CENS, type = "left") ~ ARM,
+  dist = "gaussian",
+  data = dat_used
+)
 summary(res_survreg)
 
 # Least square means by group
@@ -119,29 +113,29 @@ lsm = emmeans(res_survreg, specs = trt.vs.ctrl ~ ARM)
 lsm$emmeans
 
 # Difference between groups
-lsm_contrast = broom::tidy(lsm$contrasts, conf.int=TRUE, conf.level=0.95)
-gt(lsm_contrast) %>%
+lsm_contrast = broom::tidy(lsm$contrasts, conf.int = TRUE, conf.level = 0.95)
+lsm_contrast |>
+  gt() |>
   fmt_number(decimals = 3)
 
 # Wald-based CIs
-round(stats::confint(res_survreg, level = 0.95)[2,], 3)
+round(stats::confint(res_survreg, level = 0.95)[2, ], 3)
 ```
 
 The output provides an estimate of difference between groups A and B (B-A), namely 1.823 (se=0.806). The presented p-value is a two-sided p-value based on the Z-test. The output also provides an estimate for $log(\sigma) = 0.549$. Using the `emmeans` package/function least square means and contrast can be easily obtained. The confidence intervals and p-value is based on the t-test using `emmeans`. Wald based confidence intervals can be obtained by the `stats::confint` function.
 
-
 ### vglm
+
 The `VGAM` package provides functions for fitting vector generalized linear and additive models (VGLMs and VGAMs). This package centers on the iteratively reweighted least squares (IRLS) algorithm. The `vglm` function offers the possibility to fit a tobit model.
+
 ```{r}
 #| label: vglm
-res_vglm = vglm(Y ~ ARM,
-                tobit(Lower = 8.0),
-                data = dat_used)
+res_vglm = VGAM::vglm(Y ~ ARM, tobit(Lower = 8.0), data = dat_used)
 summary(res_vglm)
 
 # Difference between groups
 round(res_vglm@coefficients[3], 3)
-round(confintvglm(res_vglm, level = 0.95)[3,], 3)
+round(VGAM::confintvglm(res_vglm, level = 0.95)[3, ], 3)
 ```
 
 The output provides an estimate of difference between groups A and B (B-A), namely 1.823 (se=0.794). The presented p-value is a two-sided p-value based on the Z-test. Note that point estimate for the difference (and associated SE) are slightly different from the results obtained by `censReg` and `tobit` due to the difference in estimation procedure used. Wald based confidence intervals can be obtained by the `confintvglm` function. The $(Intercept):2$ in the model output is an estimate for $log(\sigma)$.
@@ -158,17 +152,16 @@ Breen, R. (1996). Regression models. SAGE Publications, Inc., https://doi.org/10
 
 Tobin, James (1958). "Estimation of Relationships for Limited Dependent Variables". Econometrica. 26 (1): 24-36. doi:10.2307/1907382
 
-
-
-
 ::: {.callout-note collapse="true" title="Session Info"}
+
 ```{r}
 #| echo: false
 
-# List all the packages needed 
+# List all the packages needed
 si <- sessioninfo::session_info(c(
-  #Create a vector of all the packages used in this file 
+  #Create a vector of all the packages used in this file
 ))
 si
 ```
+
 :::

--- a/R/tobit regression.qmd
+++ b/R/tobit regression.qmd
@@ -109,7 +109,7 @@ res_survreg = survival::survreg(
 summary(res_survreg)
 
 # Least square means by group
-lsm = emmeans(res_survreg, specs = trt.vs.ctrl ~ ARM)
+lsm = emmeans::emmeans(res_survreg, specs = trt.vs.ctrl ~ ARM)
 lsm$emmeans
 
 # Difference between groups

--- a/R/ttest_1Sample.qmd
+++ b/R/ttest_1Sample.qmd
@@ -44,8 +44,8 @@ The following code was used to test the comparison in Base R. Note that the base
 #| eval: true
 #| echo: true
 
-  # Perform t-test
-  t.test(read$score, mu = 30)
+# Perform t-test
+t.test(read$score, mu = 30)
 
 ```
 
@@ -60,11 +60,10 @@ The following code from the **procs** package was used to perform a one sample t
 #| echo: true
 #| message: false
 #| warning: false
-  library(procs)
+library(procs)
 
-  # Perform t-test
-  proc_ttest(read, var = score,
-             options = c("h0" = 30))
+# Perform t-test
+proc_ttest(read, var = score, options = c("h0" = 30))
 ```
 
 Viewer Output:

--- a/R/ttest_1Sample.qmd
+++ b/R/ttest_1Sample.qmd
@@ -1,6 +1,5 @@
 ---
 title: "One Sample t-test"
-output: html_document
 ---
 
 ```{r}
@@ -45,8 +44,7 @@ The following code was used to test the comparison in Base R. Note that the base
 #| echo: true
 
 # Perform t-test
-t.test(read$score, mu = 30)
-
+stats::t.test(read$score, mu = 30)
 ```
 
 ### Procs Package
@@ -63,7 +61,7 @@ The following code from the **procs** package was used to perform a one sample t
 library(procs)
 
 # Perform t-test
-proc_ttest(read, var = score, options = c("h0" = 30))
+procs::proc_ttest(read, var = score, options = c("h0" = 30))
 ```
 
 Viewer Output:

--- a/R/ttest_2Sample.qmd
+++ b/R/ttest_2Sample.qmd
@@ -56,7 +56,7 @@ d1p <- dplyr::filter(d1, trt_grp == 'placebo')
 d1t <- dplyr::filter(d1, trt_grp == 'treatment')
 
 # Perform t-test
-t.test(d1p$WtGain, d1t$WtGain, var.equal = TRUE, paired = FALSE)
+stats::t.test(d1p$WtGain, d1t$WtGain, var.equal = TRUE, paired = FALSE)
 
 ```
 
@@ -74,7 +74,7 @@ d1p <- dplyr::filter(d1, trt_grp == 'placebo')
 d1t <- dplyr::filter(d1, trt_grp == 'treatment')
 
 # Perform t-test
-t.test(d1p$WtGain, d1t$WtGain, var.equal = FALSE, paired = FALSE)
+stats::t.test(d1p$WtGain, d1t$WtGain, var.equal = FALSE, paired = FALSE)
 
 ```
 
@@ -93,7 +93,7 @@ The following code from the **procs** package was used to perform a two sample t
 #| warning: false
 
 # Perform t-test
-proc_ttest(d1, var = WtGain, class = trt_grp)
+procs::proc_ttest(d1, var = WtGain, class = trt_grp)
 ```
 
 Viewer Output:

--- a/R/ttest_2Sample.qmd
+++ b/R/ttest_2Sample.qmd
@@ -52,12 +52,11 @@ Also note that we must separate the single variable into two variables to satisf
 #| eval: true
 #| echo: true
 
-  d1p <- dplyr::filter(d1, trt_grp == 'placebo')
-  d1t <- dplyr::filter(d1, trt_grp == 'treatment')
+d1p <- dplyr::filter(d1, trt_grp == 'placebo')
+d1t <- dplyr::filter(d1, trt_grp == 'treatment')
 
-  # Perform t-test
-  t.test(d1p$WtGain, d1t$WtGain, 
-       var.equal = TRUE, paired = FALSE)
+# Perform t-test
+t.test(d1p$WtGain, d1t$WtGain, var.equal = TRUE, paired = FALSE)
 
 ```
 
@@ -71,12 +70,11 @@ The following code was used to test the comparison in Base R using Welch's t-tes
 #| eval: true
 #| echo: true
 
-  d1p <- dplyr::filter(d1, trt_grp == 'placebo')
-  d1t <- dplyr::filter(d1, trt_grp == 'treatment')
+d1p <- dplyr::filter(d1, trt_grp == 'placebo')
+d1t <- dplyr::filter(d1, trt_grp == 'treatment')
 
-  # Perform t-test
-  t.test(d1p$WtGain, d1t$WtGain, 
-       var.equal = FALSE, paired = FALSE)
+# Perform t-test
+t.test(d1p$WtGain, d1t$WtGain, var.equal = FALSE, paired = FALSE)
 
 ```
 
@@ -93,11 +91,9 @@ The following code from the **procs** package was used to perform a two sample t
 #| echo: true
 #| message: false
 #| warning: false
-  library(procs)
 
-  # Perform t-test
-  proc_ttest(d1, var = WtGain,
-             class = trt_grp)
+# Perform t-test
+proc_ttest(d1, var = WtGain, class = trt_grp)
 ```
 
 Viewer Output:

--- a/R/ttest_Paired.qmd
+++ b/R/ttest_Paired.qmd
@@ -1,6 +1,5 @@
 ---
 title: "Paired t-test"
-output: html_document
 ---
 
 ```{r}
@@ -55,7 +54,7 @@ The following code was used to test the comparison in Base R.
 #| echo: true
 
 # Perform t-test
-t.test(pressure$SBPbefore, pressure$SBPafter, paired = TRUE)
+stats::t.test(pressure$SBPbefore, pressure$SBPafter, paired = TRUE)
 
 ```
 
@@ -73,7 +72,7 @@ The following code from the **procs** package was used to perform a paired t-tes
 library(procs)
 
 # Perform t-test
-proc_ttest(pressure, paired = "SBPbefore*SBPafter")
+procs::proc_ttest(pressure, paired = "SBPbefore*SBPafter")
 ```
 
 Viewer Output:

--- a/R/ttest_Paired.qmd
+++ b/R/ttest_Paired.qmd
@@ -54,8 +54,8 @@ The following code was used to test the comparison in Base R.
 #| eval: true
 #| echo: true
 
-  # Perform t-test
-  t.test(pressure$SBPbefore, pressure$SBPafter, paired = TRUE)
+# Perform t-test
+t.test(pressure$SBPbefore, pressure$SBPafter, paired = TRUE)
 
 ```
 
@@ -70,11 +70,10 @@ The following code from the **procs** package was used to perform a paired t-tes
 #| echo: true
 #| message: false
 #| warning: false
-  library(procs)
+library(procs)
 
-  # Perform t-test
-  proc_ttest(pressure,
-     paired = "SBPbefore*SBPafter")
+# Perform t-test
+proc_ttest(pressure, paired = "SBPbefore*SBPafter")
 ```
 
 Viewer Output:

--- a/R/wilcoxonsr_hodges_lehman.qmd
+++ b/R/wilcoxonsr_hodges_lehman.qmd
@@ -26,7 +26,7 @@ library(MASS)
 
 knitr::opts_chunk$set(echo = TRUE)
 
-blood_p <- read.csv("../data/blood_pressure.csv", dec = ".")[1:240,1:5]
+blood_p <- read.csv("../data/blood_pressure.csv", dec = ".")[1:240, 1:5]
 
 ```
 
@@ -57,32 +57,41 @@ We will focus on the below arguments: - alternative - paired - exact - correct -
 ### Examples {.unnumbered}
 
 ```{r}
-# Exact 
-stats::wilcox.test(x = blood_p$bp_after, y = blood_p$bp_before, 
-                                   paired = TRUE, 
-                                   conf.int = TRUE, 
-                                   conf.level = 0.9, 
-                                   alterative = "two.sided", 
-                                   exact = TRUE)
+# Exact
+stats::wilcox.test(
+  x = blood_p$bp_after,
+  y = blood_p$bp_before,
+  paired = TRUE,
+  conf.int = TRUE,
+  conf.level = 0.9,
+  alterative = "two.sided",
+  exact = TRUE
+)
 
 # No exact & continuity correction
-stats::wilcox.test(x = blood_p$bp_after, y = blood_p$bp_before, 
-                                   paired = TRUE, 
-                                   conf.int = TRUE, 
-                                   conf.level = 0.9, 
-                                   alterative = "two.sided", 
-                                   exact = FALSE, 
-                                   correct = TRUE)
+stats::wilcox.test(
+  x = blood_p$bp_after,
+  y = blood_p$bp_before,
+  paired = TRUE,
+  conf.int = TRUE,
+  conf.level = 0.9,
+  alterative = "two.sided",
+  exact = FALSE,
+  correct = TRUE
+)
 
 
 # No exact & No continuity correction
-stats::wilcox.test(x = blood_p$bp_after, y = blood_p$bp_before, 
-                                     paired = TRUE, 
-                                     conf.int = TRUE, 
-                                     conf.level = 0.9, 
-                                     alterative = "two.sided" , 
-                                     exact = FALSE, 
-                                     correct = FALSE)
+stats::wilcox.test(
+  x = blood_p$bp_after,
+  y = blood_p$bp_before,
+  paired = TRUE,
+  conf.int = TRUE,
+  conf.level = 0.9,
+  alterative = "two.sided",
+  exact = FALSE,
+  correct = FALSE
+)
 
 ```
 
@@ -100,11 +109,13 @@ Function *senWilcox* used for Sensitivity Analysis for Wilcoxon's Signed-rank St
 ### Examples {.unnumbered}
 
 ```{r}
-DOS2::senWilcox(blood_p$bp_after - blood_p$bp_before, 
-                   gamma = 1, 
-                   conf.int = TRUE, 
-                   alpha = 0.1, 
-                   alternative = "twosided")
+DOS2::senWilcox(
+  blood_p$bp_after - blood_p$bp_before,
+  gamma = 1,
+  conf.int = TRUE,
+  alpha = 0.1,
+  alternative = "twosided"
+)
 ```
 
 ### Important notes on DOS2:senWilcox {.unnumbered}

--- a/R/wilcoxonsr_hodges_lehman.qmd
+++ b/R/wilcoxonsr_hodges_lehman.qmd
@@ -16,10 +16,6 @@ Additionally, *"0s"* can cause some trouble as well. For example when the differ
 library(tidyverse)
 library(broom)
 library(knitr)
-library(dplyr)
-library(tidyr)
-library(ggplot2)
-library(stats)
 library(coin)
 library(DOS2)
 library(MASS)
@@ -79,7 +75,6 @@ stats::wilcox.test(
   exact = FALSE,
   correct = TRUE
 )
-
 
 # No exact & No continuity correction
 stats::wilcox.test(

--- a/R/xgboost.qmd
+++ b/R/xgboost.qmd
@@ -40,18 +40,15 @@ Use {tidymodels} metadata package to split the data into training and testing da
 
 ```{r}
 
-birthwt <- 
-  birthwt %>% 
+birthwt <- birthwt |>
   mutate(
     low_f = lvls_revalue(factor(low), c("Not Low", "Low")),
     smoke_f = lvls_revalue(factor(smoke), c("Non-smoker", "Smoker"))
   )
 
-
 brthwt_split <- initial_split(birthwt, strata = low)
 brthwt_train <- training(brthwt_split)
 brthwt_test <- testing(brthwt_split)
-
 
 ```
 
@@ -61,23 +58,21 @@ After creating the data split, we setup the params of the model.
 
 ```{r}
 
-xgboost_spec <- 
-  boost_tree(trees = 15) %>% 
+xgboost_spec <- boost_tree(trees = 15) |>
   # This model can be used for classification or regression, so set mode
-  set_mode("classification") %>% 
+  set_mode("classification") |>
   set_engine("xgboost")
 
 xgboost_spec
 
 
-xgboost_cls_fit <- xgboost_spec %>% fit(low_f ~ ., data = brthwt_train)
+xgboost_cls_fit <- xgboost_spec |> fit(low_f ~ ., data = brthwt_train)
 xgboost_cls_fit
 
 bind_cols(
   predict(xgboost_cls_fit, brthwt_test),
   predict(xgboost_cls_fit, brthwt_test, type = "prob")
 )
-
 
 ```
 
@@ -86,20 +81,19 @@ bind_cols(
 To perform xgboost with regression, when setting up the parameter of the model, set the mode of xgboost to regression. After that switch and then changing the variable of interest back to an integer, the rest of the code is the same.
 
 ```{r}
-xgboost_reg_spec <- 
-  boost_tree(trees = 15) %>% 
+xgboost_reg_spec <- boost_tree(trees = 15) |>
   # This model can be used for classification or regression, so set mode
-  set_mode("regression") %>% 
+  set_mode("regression") |>
   set_engine("xgboost")
 
 xgboost_reg_spec
 
 # For a regression model, the outcome should be `numeric`, not a `factor`.
-xgboost_reg_fit <- xgboost_reg_spec %>% fit(low~ ., data = brthwt_train)
-xgboost_reg_fit 
+xgboost_reg_fit <- xgboost_reg_spec |>
+  fit(low ~ ., data = brthwt_train)
+xgboost_reg_fit
 
-predict(xgboost_reg_fit , brthwt_test)
-
+predict(xgboost_reg_fit, brthwt_test)
 
 ```
 
@@ -111,10 +105,11 @@ predict(xgboost_reg_fit , brthwt_test)
 ```{r}
 #| echo: false
 
-# List all the packages needed 
+# List all the packages needed
 si <- sessioninfo::session_info(c(
-  #Create a vector of all the packages used in this file 
+  #Create a vector of all the packages used in this file
 ))
 si
 ```
+
 :::

--- a/R/xgboost.qmd
+++ b/R/xgboost.qmd
@@ -26,7 +26,8 @@ Data used for this example is `birthwt` which is part of the {MASS} package. Thi
 #| output: false
 library(tidyverse)
 library(MASS)
-library(tidymodels)
+library(rsample)
+library(parsnip)
 library(xgboost)
 
 head(birthwt)
@@ -46,9 +47,9 @@ birthwt <- birthwt |>
     smoke_f = lvls_revalue(factor(smoke), c("Non-smoker", "Smoker"))
   )
 
-brthwt_split <- initial_split(birthwt, strata = low)
-brthwt_train <- training(brthwt_split)
-brthwt_test <- testing(brthwt_split)
+brthwt_split <- rsample::initial_split(birthwt, strata = low)
+brthwt_train <- rsample::training(brthwt_split)
+brthwt_test <- rsample::testing(brthwt_split)
 
 ```
 
@@ -58,15 +59,15 @@ After creating the data split, we setup the params of the model.
 
 ```{r}
 
-xgboost_spec <- boost_tree(trees = 15) |>
+xgboost_spec <- parsnip::boost_tree(trees = 15) |>
   # This model can be used for classification or regression, so set mode
-  set_mode("classification") |>
-  set_engine("xgboost")
+  parsnip::set_mode("classification") |>
+  parsnip::set_engine("xgboost")
 
 xgboost_spec
 
-
-xgboost_cls_fit <- xgboost_spec |> fit(low_f ~ ., data = brthwt_train)
+xgboost_cls_fit <- xgboost_spec |>
+  fit(low_f ~ ., data = brthwt_train)
 xgboost_cls_fit
 
 bind_cols(
@@ -81,10 +82,10 @@ bind_cols(
 To perform xgboost with regression, when setting up the parameter of the model, set the mode of xgboost to regression. After that switch and then changing the variable of interest back to an integer, the rest of the code is the same.
 
 ```{r}
-xgboost_reg_spec <- boost_tree(trees = 15) |>
+xgboost_reg_spec <- parsnip::boost_tree(trees = 15) |>
   # This model can be used for classification or regression, so set mode
-  set_mode("regression") |>
-  set_engine("xgboost")
+  parsnip::set_mode("regression") |>
+  parsnip::set_engine("xgboost")
 
 xgboost_reg_spec
 

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -29,7 +29,7 @@ website:
       - text: "Help"
         menu:
           - text: "Report a Bug"
-            icon: "bug"
+            icon: "bug-fill"
             href: "https://github.com/PSIAIMS/CAMIS/issues"
           - text: "Get Started with Your Environment"
             icon: "git"

--- a/contribution/contribution.qmd
+++ b/contribution/contribution.qmd
@@ -28,7 +28,7 @@ Welcome to CAMIS! Please read this article: [Get started](get_started.qmd), whic
 
 ### Asking for help
 
-If you need any assistance with setting up your workspace, do not hesitate to contact @DrLynTaylor, @statasaurus and @andreaczhang! For more information about how to choose an R package read this [short guidance](Package-Review.qmd)
+If you need any assistance with setting up your workspace, do not hesitate to contact @DrLynTaylor, @statasaurus and @andreaczhang! For more information about how to choose an R package read this [short guidance](package_review.qmd)
 
 ## Dissertation projects
 

--- a/contribution/get_started.qmd
+++ b/contribution/get_started.qmd
@@ -45,7 +45,7 @@ Go into RStudio and Create a branch -- Give you are working from your own fork, 
 
 ### Start writing
 
-Edit and /or add files within the CAMIS directories. If you are adding SAS guidance store under sas folder, R guidance store under r folder, for "SAS vs R" comparison store under comp. Follow the naming convention of the files already stored in those folders. For more information about how to choose an R package read this [short guidance](Package-Review.qmd)
+Edit and /or add files within the CAMIS directories. If you are adding SAS guidance store under sas folder, R guidance store under r folder, for "SAS vs R" comparison store under comp. Follow the naming convention of the files already stored in those folders. For more information about how to choose an R package read this [short guidance](package_review.qmd)
 
 ### Commit your changes, push to remote
 

--- a/renv.lock
+++ b/renv.lock
@@ -112,16 +112,6 @@
       ],
       "Hash": "3cdd73c0534df2123efc25236ec23295"
     },
-    "DiceDesign": {
-      "Package": "DiceDesign",
-      "Version": "1.10",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
-      "Hash": "ac8b12951882c375d1a14f64c93e78f1"
-    },
     "Exact": {
       "Package": "Exact",
       "Version": "3.3",
@@ -174,17 +164,6 @@
       ],
       "Hash": "7a29697b75e027767a53fde6c903eca7"
     },
-    "GPfit": {
-      "Package": "GPfit",
-      "Version": "1.0-8",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "lattice",
-        "lhs"
-      ],
-      "Hash": "29a7dccade1fd037c8262c2a239775eb"
-    },
     "HSAUR2": {
       "Package": "HSAUR2",
       "Version": "1.1-20",
@@ -202,17 +181,6 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "aee647d15e5541ad44d157f7b78fda01"
-    },
-    "KernSmooth": {
-      "Package": "KernSmooth",
-      "Version": "2.23-24",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "stats"
-      ],
-      "Hash": "9f33a1ee37bbe8919eb2ec4b9f2473a5"
     },
     "MASS": {
       "Package": "MASS",
@@ -373,16 +341,6 @@
         "utils"
       ],
       "Hash": "24a964d2cf75ad25d7b843856c8d4c93"
-    },
-    "SQUAREM": {
-      "Package": "SQUAREM",
-      "Version": "2021.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
-      "Hash": "0cf10dab0d023d5b46a5a14387556891"
     },
     "SampleSize4ClinicalTrials": {
       "Package": "SampleSize4ClinicalTrials",
@@ -878,22 +836,6 @@
       ],
       "Hash": "3f038e5ac7f41d4ac41ce658c85e3042"
     },
-    "clock": {
-      "Package": "clock",
-      "Version": "0.7.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "cli",
-        "cpp11",
-        "lifecycle",
-        "rlang",
-        "tzdb",
-        "vctrs"
-      ],
-      "Hash": "3dcaebd52554438d12989e5061e15de8"
-    },
     "cluster": {
       "Package": "cluster",
       "Version": "2.1.6",
@@ -1186,44 +1128,6 @@
       ],
       "Hash": "64c0eb2b740ab1ac553d928b3a75d72a"
     },
-    "diagram": {
-      "Package": "diagram",
-      "Version": "1.6.5",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "graphics",
-        "shape",
-        "stats"
-      ],
-      "Hash": "c7f527c59edc72c4bce63519b8d38752"
-    },
-    "dials": {
-      "Package": "dials",
-      "Version": "1.3.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "DiceDesign",
-        "R",
-        "cli",
-        "dplyr",
-        "glue",
-        "hardhat",
-        "lifecycle",
-        "pillar",
-        "purrr",
-        "rlang",
-        "scales",
-        "sfd",
-        "tibble",
-        "utils",
-        "vctrs",
-        "withr"
-      ],
-      "Hash": "f2fbe4e90fab23fc1f95bffcd3662878"
-    },
     "diffobj": {
       "Package": "diffobj",
       "Version": "0.3.5",
@@ -1290,22 +1194,6 @@
         "tidyr"
       ],
       "Hash": "8ddf795104defe53c5392a588888ec68"
-    },
-    "doFuture": {
-      "Package": "doFuture",
-      "Version": "1.0.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "foreach",
-        "future",
-        "future.apply",
-        "globals",
-        "iterators",
-        "parallel",
-        "utils"
-      ],
-      "Hash": "bd269daa182b205fa471c89ee9dcc8df"
     },
     "dplyr": {
       "Package": "dplyr",
@@ -1687,20 +1575,6 @@
       ],
       "Hash": "475771e3edb711591476be387c9a8c2e"
     },
-    "future.apply": {
-      "Package": "future.apply",
-      "Version": "1.11.2",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "future",
-        "globals",
-        "parallel",
-        "utils"
-      ],
-      "Hash": "afe1507511629f44572e6c53b9baeb7c"
-    },
     "gargle": {
       "Package": "gargle",
       "Version": "1.5.2",
@@ -2038,13 +1912,6 @@
       ],
       "Hash": "d6db1667059d027da730decdc214b959"
     },
-    "gower": {
-      "Package": "gower",
-      "Version": "1.0.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "7a0051eef852c301b5efe2f7913dd45f"
-    },
     "gridExtra": {
       "Package": "gridExtra",
       "Version": "2.3",
@@ -2346,32 +2213,6 @@
       ],
       "Hash": "99df65cfef20e525ed38c3d2577f7190"
     },
-    "infer": {
-      "Package": "infer",
-      "Version": "1.0.7",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "broom",
-        "cli",
-        "dplyr",
-        "generics",
-        "ggplot2",
-        "glue",
-        "grDevices",
-        "lifecycle",
-        "magrittr",
-        "methods",
-        "patchwork",
-        "purrr",
-        "rlang",
-        "tibble",
-        "tidyr",
-        "vctrs"
-      ],
-      "Hash": "8d30ac9c5e21efd8575f934bdb5c3029"
-    },
     "inline": {
       "Package": "inline",
       "Version": "0.3.21",
@@ -2381,22 +2222,6 @@
         "methods"
       ],
       "Hash": "a816db522447eb5ca56e7d4e6e82e4eb"
-    },
-    "ipred": {
-      "Package": "ipred",
-      "Version": "0.9-15",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "MASS",
-        "R",
-        "class",
-        "nnet",
-        "prodlim",
-        "rpart",
-        "survival"
-      ],
-      "Hash": "3c3e02183ef7b9225213b531d0ce43f5"
     },
     "isoband": {
       "Package": "isoband",
@@ -2581,27 +2406,6 @@
       ],
       "Hash": "cc5ac1ba4c238c7ca9fa6a87ca11a7e2"
     },
-    "lava": {
-      "Package": "lava",
-      "Version": "1.8.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "SQUAREM",
-        "cli",
-        "future.apply",
-        "grDevices",
-        "graphics",
-        "methods",
-        "numDeriv",
-        "progressr",
-        "stats",
-        "survival",
-        "utils"
-      ],
-      "Hash": "579303ca1e817d94cea694b319803380"
-    },
     "lazyeval": {
       "Package": "lazyeval",
       "Version": "0.2.2",
@@ -2618,17 +2422,6 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "06ddb0b69b0714ae929b1b6029d6faf0"
-    },
-    "lhs": {
-      "Package": "lhs",
-      "Version": "1.2.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "Rcpp"
-      ],
-      "Hash": "6d18e58d3d1de31b6e5415c1fe291113"
     },
     "libcoin": {
       "Package": "libcoin",
@@ -2971,34 +2764,6 @@
         "utils"
       ],
       "Hash": "155806c4165a15ef11cefddfb635bb9e"
-    },
-    "modeldata": {
-      "Package": "modeldata",
-      "Version": "1.4.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "MASS",
-        "R",
-        "dplyr",
-        "purrr",
-        "rlang",
-        "tibble"
-      ],
-      "Hash": "a88b3cef9f6a41e075163e767ad8c8fa"
-    },
-    "modelenv": {
-      "Package": "modelenv",
-      "Version": "0.1.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "glue",
-        "rlang",
-        "tibble",
-        "vctrs"
-      ],
-      "Hash": "fc2e59a68030885555c7be34ee7765a1"
     },
     "modelr": {
       "Package": "modelr",
@@ -3540,25 +3305,6 @@
       ],
       "Hash": "44cd799f1fa36d285493ac094f4f7eea"
     },
-    "prodlim": {
-      "Package": "prodlim",
-      "Version": "2024.06.25",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "KernSmooth",
-        "R",
-        "Rcpp",
-        "data.table",
-        "diagram",
-        "grDevices",
-        "graphics",
-        "lava",
-        "stats",
-        "survival"
-      ],
-      "Hash": "d1e73a231e9442c29e21876f303382fc"
-    },
     "progress": {
       "Package": "progress",
       "Version": "1.2.3",
@@ -3572,18 +3318,6 @@
         "prettyunits"
       ],
       "Hash": "f4625e061cb2865f111b47ff163a5ca6"
-    },
-    "progressr": {
-      "Package": "progressr",
-      "Version": "0.14.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "digest",
-        "utils"
-      ],
-      "Hash": "ac50c4ffa8f6a46580dd4d7813add3c4"
     },
     "promises": {
       "Package": "promises",
@@ -3799,38 +3533,6 @@
         "utils"
       ],
       "Hash": "8cf9c239b96df1bbb133b74aef77ad0a"
-    },
-    "recipes": {
-      "Package": "recipes",
-      "Version": "1.1.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "Matrix",
-        "R",
-        "cli",
-        "clock",
-        "dplyr",
-        "generics",
-        "glue",
-        "gower",
-        "hardhat",
-        "ipred",
-        "lifecycle",
-        "lubridate",
-        "magrittr",
-        "purrr",
-        "rlang",
-        "stats",
-        "tibble",
-        "tidyr",
-        "tidyselect",
-        "timeDate",
-        "utils",
-        "vctrs",
-        "withr"
-      ],
-      "Hash": "fc6672e55fcd1b5c461a3529ff6b1b08"
     },
     "relimp": {
       "Package": "relimp",
@@ -4280,19 +3982,6 @@
       ],
       "Hash": "3f9796a8d0a0e8c6eb49a4b029359d1f"
     },
-    "sfd": {
-      "Package": "sfd",
-      "Version": "0.1.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "cli",
-        "rlang",
-        "tibble"
-      ],
-      "Hash": "8798f23058ead1d2ffd1223dfc0c8906"
-    },
     "shape": {
       "Package": "shape",
       "Version": "1.4.6.1",
@@ -4576,37 +4265,6 @@
       ],
       "Hash": "62e5e75e469d85b239d9548b04f80059"
     },
-    "tidymodels": {
-      "Package": "tidymodels",
-      "Version": "1.2.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "broom",
-        "cli",
-        "conflicted",
-        "dials",
-        "dplyr",
-        "ggplot2",
-        "hardhat",
-        "infer",
-        "modeldata",
-        "parsnip",
-        "purrr",
-        "recipes",
-        "rlang",
-        "rsample",
-        "rstudioapi",
-        "tibble",
-        "tidyr",
-        "tune",
-        "workflows",
-        "workflowsets",
-        "yardstick"
-      ],
-      "Hash": "c3296bbe8389a31fafc1ee07e69889a7"
-    },
     "tidyr": {
       "Package": "tidyr",
       "Version": "1.3.1",
@@ -4686,20 +4344,6 @@
       ],
       "Hash": "c328568cd14ea89a83bd4ca7f54ae07e"
     },
-    "timeDate": {
-      "Package": "timeDate",
-      "Version": "4041.110",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "graphics",
-        "methods",
-        "stats",
-        "utils"
-      ],
-      "Hash": "c5e48e8ac24d4472ddb122bcdeb011ad"
-    },
     "timechange": {
       "Package": "timechange",
       "Version": "0.3.0",
@@ -4720,40 +4364,6 @@
         "xfun"
       ],
       "Hash": "9db859e8aabbb474293dde3097839420"
-    },
-    "tune": {
-      "Package": "tune",
-      "Version": "1.2.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "GPfit",
-        "R",
-        "cli",
-        "dials",
-        "doFuture",
-        "dplyr",
-        "foreach",
-        "future",
-        "generics",
-        "ggplot2",
-        "glue",
-        "hardhat",
-        "lifecycle",
-        "parsnip",
-        "purrr",
-        "recipes",
-        "rlang",
-        "rsample",
-        "tibble",
-        "tidyr",
-        "tidyselect",
-        "vctrs",
-        "withr",
-        "workflows",
-        "yardstick"
-      ],
-      "Hash": "7fbdbcd58e7a63957b23ddb751b346af"
     },
     "tzdb": {
       "Package": "tzdb",
@@ -4940,56 +4550,6 @@
       ],
       "Hash": "07909200e8bbe90426fbfeb73e1e27aa"
     },
-    "workflows": {
-      "Package": "workflows",
-      "Version": "1.1.4",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "cli",
-        "generics",
-        "glue",
-        "hardhat",
-        "lifecycle",
-        "modelenv",
-        "parsnip",
-        "rlang",
-        "tidyselect",
-        "vctrs"
-      ],
-      "Hash": "f2c2cefdf6babfed4594b33479d19fc3"
-    },
-    "workflowsets": {
-      "Package": "workflowsets",
-      "Version": "1.1.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "cli",
-        "dplyr",
-        "generics",
-        "ggplot2",
-        "glue",
-        "hardhat",
-        "lifecycle",
-        "parsnip",
-        "pillar",
-        "prettyunits",
-        "purrr",
-        "rlang",
-        "rsample",
-        "stats",
-        "tibble",
-        "tidyr",
-        "tune",
-        "vctrs",
-        "withr",
-        "workflows"
-      ],
-      "Hash": "ff4540bb4cccc1dd2447d58a97158820"
-    },
     "xfun": {
       "Package": "xfun",
       "Version": "0.52",
@@ -5048,27 +4608,6 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "51dab85c6c98e50a18d7551e9d49f76c"
-    },
-    "yardstick": {
-      "Package": "yardstick",
-      "Version": "1.3.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "cli",
-        "dplyr",
-        "generics",
-        "hardhat",
-        "lifecycle",
-        "rlang",
-        "tibble",
-        "tidyselect",
-        "utils",
-        "vctrs",
-        "withr"
-      ],
-      "Hash": "9ce4117141b326c4fffc7c42e56e0f88"
     },
     "zip": {
       "Package": "zip",


### PR DESCRIPTION
### Main Changes
1. Formatted all files with [Air](https://posit-dev.github.io/air/), Posit's new R formatter. This applied consistency in spacing of code in these R code chunks. I find these code formatting changes to be an improvement in the readability of the code. I understand and have similar parts that I don't like, but I think this brings greater consistency to the project, irrespective of if people in the future don't follow this exactly and more changes have to be made later.
2. Removed the `magrittr` pipe `%>%` in favor of the base R pipe `|>`, which has been functional since `R 4.1`. See [this blog](https://www.tidyverse.org/blog/2023/04/base-vs-magrittr-pipe/) for more details. Indeed, Posit has begun to replace and use the base R pipe in many of their [own packages](https://style.tidyverse.org/pipes.html) 
    >We recommend you use the base |> pipe instead of magrittr’s %>%.
3. Prefixed specific package names in various functions to make it more explicit to the reader which packages are being used. I left many that are either `stats` or `tidyverse` specific packages alone and focused solely on packages and functions that were used in the statistical examples.
4. Adjusted some of the comment and line spacing in files in an effort to make the code easier to read, especially in places with large continuous code chunks.
5. There were some changes related to text or bullet points, where it didn't seem like the bullet points were actually being rendered in text due to spacing issues. These changes should resolve that, for example in the `R/anova.qmd` file.
6. I also updated the `renv.lock` file as in looking at the `R/xgboost.qmd` file, only a few `tidymodels` packages were actually used, so I specified those and removed the call to `tidymodels` which removed some dependencies. (I'd say thats good!)
7. Finally, I removed specific callouts in the Quarto document yaml options that included `editor` or `output` calls as those are all specified, set, and inherited from the `_quarto.yml` file, thus within individual documents would be redundant.

### What I didn't Touch or Add
- I did not try to make the files themselves consistent regarding any language, placement of code chunks (library calls), or code chunk yaml options (echo, message, warming, etc). Those could be undertaken at some point, but I felt they were beyond my intent.
- I did not add any files or specifics related to Air formatting, as it doesn't work in RStudio. I edited everything in Positron, rendered in RStudio to catch any errors, and only pushed the files and not any `_freeze` changes here.
- I think a larger aim and goal, would be to make the underlying data used for this repository more consistent and smilar, or expand the examples used to include a few different datasets. I think having two or three different data sets compared within a single file (here I'm thinking of comparing only within the language specific files `R/` or `SAS/`; whilein the `Comp` folders, only a single dataset would be used).
  - This would be helpful as currently many files use their own 'datasets' or specify data through a `tribble` or `tibble` call for a single file. Those calls could be removed to rely on the datasets in the `data/` folder.

I will make a separate pull request for R code changes in the `Comp/` folder and where other R code is. This should make progress on #446.