### PR TITLE
SAS formatting updates in the `SAS/` folder

### DIFF
--- a/SAS/SAS_Friedmantest.qmd
+++ b/SAS/SAS_Friedmantest.qmd
@@ -18,15 +18,15 @@ Simulated dataset of 10 subjects(blocks) with continuous endpoints are generated
 
 ## Data source
 
-```{r}
+```{sas}
 #| eval: false
 data one_way_repeat;
-   do subject = 1 to 10;
-   	do timepoint = 1 to 4;
+  do subject = 1 to 10;
+    do timepoint = 1 to 4;
       response = round(rand('Uniform',10,50));
       output;
-	end;
-   end;
+    end;
+  end;
 run;
 
 proc print;
@@ -49,17 +49,17 @@ When the data contains missing response, the procedure discards the correspondin
 
 ## Example Code for Friedman Chi-square test
 
-```{r}
+```{sas}
 #| eval: false
 proc freq data=one_way_repeat;
-      tables subject*timepoint*response / 
-             cmh2 scores=rank noprint;
+    tables subject*timepoint*response / 
+            cmh2 scores=rank noprint;
 run;
 ```
 
 ## Results
 
-```         
+```default
                                                The FREQ Procedure
 
                                   Summary Statistics for timepoint by response

--- a/SAS/ancova.qmd
+++ b/SAS/ancova.qmd
@@ -1,6 +1,5 @@
 ---
 title: "Ancova"
-output: html_document
 date: "2024-02-20"
 ---
 
@@ -12,17 +11,17 @@ knitr::opts_chunk$set(echo = TRUE)
 
 # **ANCOVA in SAS**
 
-In SAS, there are several ways to perform ANCOVA analysis.  One common way is to use PROC GLM with the LSMEANS option. The below 
-example will use this method.
+In SAS, there are several ways to perform ANCOVA analysis. One common way is to use PROC GLM with the LSMEANS option. The below example will use this method.
 
 ### Data Used
 
 The following data was used in this example.
 
-```         
-  data DrugTest;
-     input Drug $ PreTreatment PostTreatment @@;
-     datalines;
+```{sas}
+#| eval: false
+data DrugTest;
+    input Drug $ PreTreatment PostTreatment @@;
+    datalines;
   A 11  6   A  8  0   A  5  2   A 14  8   A 19 11
   A  6  4   A 10 13   A  6  1   A 11  8   A  3  0
   D  6  0   D  6  2   D  7  3   D  8  1   D 18 18
@@ -36,14 +35,15 @@ The following data was used in this example.
 
 The following code was used to test the effects of a drug pre and post treatment:
 
-```         
-  proc glm data=DrugTest;
-     class Drug;
-     model PostTreatment = Drug PreTreatment / solution;
-     lsmeans Drug / stderr pdiff cov out=adjmeans;
-  run;
-  proc print data=adjmeans;
-  run;
+```{sas}
+#| eval: false
+proc glm data=DrugTest;
+    class Drug;
+    model PostTreatment = Drug PreTreatment / solution;
+    lsmeans Drug / stderr pdiff cov out=adjmeans;
+run;
+proc print data=adjmeans;
+run;
 ```
 
 Output:
@@ -58,6 +58,4 @@ knitr::include_graphics("../images/ancova/sas_ancova2.png")
 knitr::include_graphics("../images/ancova/sas_ancova3.png")
 ```
 
-As can be seen in the images above, the GLM procedure provides multiple types of analysis to determine the relationship
-between the dependent and independent variables.  The last step produces a table of LSMEANS and coefficient of variation values
-for each of the three different drugs in the dataset.
+As can be seen in the images above, the GLM procedure provides multiple types of analysis to determine the relationship between the dependent and independent variables. The last step produces a table of LSMEANS and coefficient of variation values for each of the three different drugs in the dataset.

--- a/SAS/anova.qmd
+++ b/SAS/anova.qmd
@@ -10,16 +10,16 @@ To demonstrate the various types of sums of squares, we'll create a data frame c
 
 For this example, we're testing for a significant difference in `stem_length` using ANOVA.
 
-```{SAS}
+```{sas}
 #| eval: false
 proc glm data = disease;
-   class drug disease;
-   model y=drug disease drug*disease;
+    class drug disease;
+    model y=drug disease drug*disease;
 run;
 ```
 
 ```{r}
-#| echo: false 
+#| echo: false
 #| fig.align: 'center'
 #| out.width: '90%'
 knitr::include_graphics("../images/linear/sas-f-table.png")
@@ -29,11 +29,11 @@ knitr::include_graphics("../images/linear/sas-f-table.png")
 
 SAS has four types of sums of squares calculations. To get these calculations, the sum of squares option needs to be added (`/ ss1 ss2 ss3 ss4`) to the model statement.
 
-```{r}
+```{sas}
 #| eval: false
 proc glm;
-   class drug disease;
-   model y=drug disease drug*disease / ss1 ss2 ss3 ss4;
+    class drug disease;
+    model y=drug disease drug*disease / ss1 ss2 ss3 ss4;
 run;
 ```
 
@@ -77,13 +77,13 @@ knitr::include_graphics("../images/linear/sas-ss-type-4.png")
 
 To get contrasts in SAS, we use the `estimate` statement. For looking at contrast we are going to fit a different model on new data, that doesn't include an interaction term as it is easier to calculate contrasts without an interaction term. For this dataset we have three different drugs A, C, and E.
 
-```{SAS}
+```{sas}
 #| eval: false
 proc glm data=testdata;
     class drug;
-   model post = drug pre / solution;
-   estimate 'C vs A'  drug -1  1 0;
-   estimate 'E vs CA' drug -1 -1 2;
+    model post = drug pre / solution;
+    estimate 'C vs A'  drug -1  1 0;
+    estimate 'E vs CA' drug -1 -1 2;
 run;
 ```
 

--- a/SAS/association.qmd
+++ b/SAS/association.qmd
@@ -2,25 +2,21 @@
 title: "Association Analysis for Count Data Using SAS"
 ---
 
-```{r}
-#| echo: FALSE
-#| include: FALSE
-```
-
 In SAS, association analysis methods for count data/contingency tables is typically performed using the `PROC FREQ` procedure. This procedure has options for Chi-Square and Fisher's Exact tests.
 
 # Example: Lung Cancer Data
 
 The following tabulation was used for the SAS Chi-Square and Fisher's testing. This tabulation was derived from the same `lung` dataset used for the R function testing. The dataset is defined as follows:
 
-```         
+```{sas}
+#| eval: false
 data test_case; 
-input treatment $ Count Weight $; 
-datalines; 
-Trt_A 22 0
-Trt_B 39 0
-Trt_A 39 1
-Trt_B 113 1
+  input treatment $ Count Weight $; 
+  datalines; 
+  Trt_A 22 0
+  Trt_B 39 0
+  Trt_A 39 1
+  Trt_B 113 1
 ; 
 ```
 
@@ -28,11 +24,12 @@ Trt_B 113 1
 
 The following SAS code produces both the Chi-Square and Fisher's Exact tests of association. Note that the results contain many statistics not produced by the corresponding R function. The relevant sections of the output have been outlined in red.
 
-```         
+```{sas}
+#| eval: false
 proc freq data = test_case;
-weight Count;
-tables treatment * Weight / chisq fisher;
-exact or;
+    weight Count;
+    tables treatment * Weight / chisq fisher;
+    exact or;
 run;
 ```
 

--- a/SAS/binomial_test.qmd
+++ b/SAS/binomial_test.qmd
@@ -1,16 +1,13 @@
-
 ---
 title: "Binomial Test on Coin Flips and Clinical Data"
-format: html
-execute:
-  echo: true
 ---
 
 ## Simulating Coin Flips
 
 Set the seed for reproducibility and simulate 1000 coin flips using a Bernoulli distribution.
 
-```sas
+```{sas}
+#| eval: false
 /* Set the seed for reproducibility */
 %let seed = 19;
 
@@ -31,7 +28,8 @@ run;
 
 Use SQL to count how many heads and tails were observed in the simulation.
 
-```sas
+```{sas}
+#| eval: false
 proc sql;
     select 
         sum(result = "H") as heads_count,
@@ -46,7 +44,8 @@ quit;
 
 Print the counts using `%put` statements.
 
-```sas
+```{sas}
+#| eval: false
 %put Heads Count: &heads_count;
 %put Tails Count: &tails_count;
 %put Total Flips: &total_flips;
@@ -56,13 +55,11 @@ Print the counts using `%put` statements.
 
 Use `proc freq` to check if the observed results differ significantly from the expected probability of 0.5.
 
-```sas
+```{sas}
 proc freq data=coin_flips;
     tables result / binomial(p=0.5);
 run;
 ```
-
----
 
 ## Example: Binomial Test in Clinical Trial Data
 
@@ -70,7 +67,8 @@ We load a clinical dataset and test if the observed death proportion is signific
 
 ### Import Dataset
 
-```sas
+```{sas}
+#| eval: false
 proc import datafile='/home/u63532805/CAMIS/lung_cancer.csv'
     out=lung_cancer
     dbms=csv
@@ -81,7 +79,8 @@ run;
 
 ### Create Binary Flag for Deaths
 
-```sas
+```{sas}
+#| eval: false
 data lung_cancer;
     set lung_cancer;
     death_flag = (status = 1);
@@ -90,7 +89,8 @@ run;
 
 ### Perform Exact Binomial Test
 
-```sas
+```{sas}
+#| eval: false
 proc freq data=lung_cancer;
     tables death_flag / binomial(p=0.19 level='1');
     title "Exact Binomial Test for Death Proportion";
@@ -110,57 +110,55 @@ run;
 **The FREQ Procedure**
 
 | result | Frequency | Percent | Cumulative Frequency | Cumulative Percent |
-|--------|-----------|---------|----------------------|---------------------|
-| H      | 520       | 52.00   | 520                  | 52.00               |
-| T      | 480       | 48.00   | 1000                 | 100.00              |
+|--------|-----------|---------|----------------------|--------------------|
+| H      | 520       | 52.00   | 520                  | 52.00              |
+| T      | 480       | 48.00   | 1000                 | 100.00             |
 
 **Binomial Proportion for result = H**
 
-- Proportion: 0.5200  
-- ASE: 0.0158  
-- 95% Lower Conf Limit: 0.4890  
-- 95% Upper Conf Limit: 0.5510  
+-   Proportion: 0.5200\
+-   ASE: 0.0158\
+-   95% Lower Conf Limit: 0.4890\
+-   95% Upper Conf Limit: 0.5510
 
 **Exact Confidence Limits**
 
-- 95% Lower Conf Limit: 0.4885  
-- 95% Upper Conf Limit: 0.5514  
+-   95% Lower Conf Limit: 0.4885\
+-   95% Upper Conf Limit: 0.5514
 
 **Test of H0: Proportion = 0.5**
 
-- ASE under H0: 0.0158  
-- Z: 1.2649  
-- One-sided Pr > Z: 0.1030  
-- Two-sided Pr > |Z|: 0.2059  
-- Sample Size: 1000  
-
----
+-   ASE under H0: 0.0158\
+-   Z: 1.2649\
+-   One-sided Pr \> Z: 0.1030\
+-   Two-sided Pr \> \|Z\|: 0.2059\
+-   Sample Size: 1000
 
 ### Exact Binomial Test for Death Proportion
 
 **The FREQ Procedure**
 
 | death_flag | Frequency | Percent | Cumulative Frequency | Cumulative Percent |
-|------------|-----------|---------|----------------------|---------------------|
-| 0          | 165       | 72.37   | 165                  | 72.37               |
-| 1          | 63        | 27.63   | 228                  | 100.00              |
+|------------|-----------|---------|----------------------|--------------------|
+| 0          | 165       | 72.37   | 165                  | 72.37              |
+| 1          | 63        | 27.63   | 228                  | 100.00             |
 
 **Binomial Proportion for death_flag = 1**
 
-- Proportion: 0.2763  
-- ASE: 0.0296  
-- 95% Lower Conf Limit: 0.2183  
-- 95% Upper Conf Limit: 0.3344  
+-   Proportion: 0.2763\
+-   ASE: 0.0296\
+-   95% Lower Conf Limit: 0.2183\
+-   95% Upper Conf Limit: 0.3344
 
 **Exact Confidence Limits**
 
-- 95% Lower Conf Limit: 0.2193  
-- 95% Upper Conf Limit: 0.3392  
+-   95% Lower Conf Limit: 0.2193\
+-   95% Upper Conf Limit: 0.3392
 
 **Test of H0: Proportion = 0.19**
 
-- ASE under H0: 0.0260  
-- Z: 3.3223  
-- One-sided Pr > Z: 0.0004  
-- Two-sided Pr > |Z|: 0.0009  
-- Sample Size: 228  
+-   ASE under H0: 0.0260\
+-   Z: 3.3223\
+-   One-sided Pr \> Z: 0.0004\
+-   Two-sided Pr \> \|Z\|: 0.0009\
+-   Sample Size: 228

--- a/SAS/ci_for_prop.qmd
+++ b/SAS/ci_for_prop.qmd
@@ -22,7 +22,7 @@ For more information about these methods in R & SAS, including which performs be
 
 The adcibc data stored [here](../data/adcibc.csv) was used in this example, creating a binary treatment variable `trt` taking the values of `Act` or `PBO` and a binary response variable `resp` taking the values of `Yes` or `No`. For this example, a response is defined as a score greater than 4.
 
-```{r}
+```{sas}
 #| eval: false
 data adcibc2 (keep=trt resp) ;
     set adcibc;     
@@ -35,10 +35,10 @@ run;
 
 The below shows that for the Actual Treatment, there are 36 responders out of 154 subjects = 0.2338 (23.38% responders).
 
-```{r}
+```{sas}
 #| eval: false 
 proc freq data=adcibc;
-  table trt*resp/ nopct nocol;
+    table trt*resp/ nopct nocol;
 run;
 ```
 
@@ -148,15 +148,15 @@ By adding the option `BINOMIAL(LEVEL="Yes")` to your 'PROC FREQ', SAS outputs th
 
 The output consists of the proportion of resp=Yes, the Asymptotic SE, 95% CIs using normal-approximation method, 95% CI using the Clopper-Pearson method (Exact), and then a Binomial test statistic and p-value for the null hypothesis of H0: Proportion = 0.5.
 
-```{R}
+```{sas}
 #| eval: false
 proc sort data=adcibc;
-by trt; 
+    by trt; 
 run; 
 
 proc freq data=adcibc ; 
-table resp/ nopct nocol BINOMIAL(LEVEL="Yes");
-by trt;
+    table resp/ nopct nocol BINOMIAL(LEVEL="Yes");
+    by trt;
 run;
 ```
 
@@ -177,18 +177,16 @@ By adding the option `BINOMIAL(LEVEL="Yes" CL=<name of CI method>)`, the other C
 
 -   `BINOMIALc(LEVEL="Yes" CL=WILSON(CORRECT)  WALD(CORRECT));`will return Wilson(with continuity correction) and Wald (with continuity correction)
 
-```{R}
+```{sas}
 #| eval: false
-
 proc freq data=adcibc;
-         table resp/ nopct nocol 
-                     BINOMIAL(LEVEL="Yes" 
-                              CL= CLOPPERPEARSON WALD WILSON 
-                                  AGRESTICOULL JEFFREYS MIDP 
-                                  LIKELIHOODRATIO LOGIT BLAKER);
-  by trt; 
+    table resp/ nopct nocol 
+    BINOMIAL(LEVEL="Yes" 
+            CL= CLOPPERPEARSON WALD WILSON 
+            AGRESTICOULL JEFFREYS MIDP 
+            LIKELIHOODRATIO LOGIT BLAKER);
+    by trt;
 run;
-
 ```
 
 ```{r}
@@ -198,14 +196,13 @@ run;
 knitr::include_graphics("../images/ci_for_prop/binomial_prop_all_act.png")
 ```
 
-```{R}
+```{sas}
 #| eval: false
-
 proc freq data=adcibc;
-         table resp/ nopct nocol 
-                     BINOMIAL(LEVEL="Yes" 
-                              CL= WILSON(CORRECT)  WALD(CORRECT));
-  by trt; 
+    table resp/ nopct nocol 
+        BINOMIAL(LEVEL="Yes" 
+        CL= WILSON(CORRECT)  WALD(CORRECT));
+    by trt; 
 run;
 
 ```
@@ -234,16 +231,16 @@ In all these cases, the calculated proportions for the 2 groups are not independ
 
 Using a cross over study as our example, a 2 x 2 table can be formed as follows:
 
-+-----------------------+---------------+---------------+--------------+
-|                       | Placebo\      | Placebo\      | Total        |
-|                       | Response= Yes | Response = No |              |
-+=======================+===============+===============+==============+
-| Active Response = Yes | r             | s             | r+s          |
-+-----------------------+---------------+---------------+--------------+
-| Active Response = No  | t             | u             | t+u          |
-+-----------------------+---------------+---------------+--------------+
-| Total                 | r+t           | s+u           | N = r+s+t+u  |
-+-----------------------+---------------+---------------+--------------+
++-----------------------+---------------+---------------+---------------+
+|                       | Placebo\      | Placebo\      | Total         |
+|                       | Response= Yes | Response = No |               |
++=======================+===============+===============+===============+
+| Active Response = Yes | r             | s             | r+s           |
++-----------------------+---------------+---------------+---------------+
+| Active Response = No  | t             | u             | t+u           |
++-----------------------+---------------+---------------+---------------+
+| Total                 | r+t           | s+u           | N = r+s+t+u   |
++-----------------------+---------------+---------------+---------------+
 
 The proportions of subjects responding on each treatment are:
 
@@ -352,10 +349,10 @@ The default method is Mantel-Haenszel confidence limits. SAS can also Score (Mie
 
 As you can see below, this is not a CI for difference in proportions of 0.196, it is a CI for the risk difference of 0.0260. So must be interpreted with much consideration.
 
-```{R}
+```{sas}
 #| eval: false 
 proc freq data=adcibc; 
-table act*pbo/commonriskdiff(cl=MH); 
+    table act*pbo/commonriskdiff(cl=MH); 
 run;
 ```
 
@@ -370,23 +367,21 @@ knitr::include_graphics("../images/ci_for_prop/riskdiff_matched.png")
 
 This [paper](https://www.lexjansen.com/wuss/2016/127_Final_Paper_PDF.pdf)^8^ describes many methods for the calculation of confidence intervals for 2 independent proportions. The most commonly used are: Wald with continuity correction and Wilson with continuity correction. The Wilson method may be more applicable when sample sizes are smaller and/or the proportion is closer to 0 or 1, since reliance on a normal distribution may be inappropriate.
 
-SAS is able to calculate CIs using the following methods: 
-Exact, Agresti/Caffo, Wald, Wald with Continuity correction, Wilson/Newcombe Score, Wilson/Newcombe score with continuity correction, Miettinen and Nurminen, and Hauck-Anderson. Example code is shown below, before provision of a much more detailed analysis using Wald and Wilson with and without continuity correction. 
-```{R}
+SAS is able to calculate CIs using the following methods: Exact, Agresti/Caffo, Wald, Wald with Continuity correction, Wilson/Newcombe Score, Wilson/Newcombe score with continuity correction, Miettinen and Nurminen, and Hauck-Anderson. Example code is shown below, before provision of a much more detailed analysis using Wald and Wilson with and without continuity correction.
+
+```{sas}
 #| eval: false
 # Wald, Wilson, Agresti/Caffo, Hauck-Anderson, and Miettinen and Nurminen methods
 proc freq data=adcibc order=data;
-table trt*resp /riskdiff(CL=(wald wilson ac ha mn ));
+    table trt*resp /riskdiff(CL=(wald wilson ac ha mn ));
 run;
 
 # exact method
 proc freq data=adcibc order=data;
-exact riskdiff (method=noscore);
-table trt*resp/riskdiff(CL=(exact)); 
+    exact riskdiff (method=noscore);
+    table trt*resp/riskdiff(CL=(exact)); 
 run;
-
 ```
-
 
 ### Normal Approximation Method (Also known as the Wald or asymptotic CI Method)
 
@@ -430,21 +425,20 @@ It is important to check the output to ensure that you are modelling Active - Pl
 
 Options for riskdiff(CL=XXX) consist of AC:Agresti-Caffo, EXACT=exact, HA:Hauck-Anderson, MN or SCORE:Miettinen-Nurminen (another type of Score CI), WILSON or NEWCOMBE: Wilson method described above, and WALD: normal approximation wald method described above. Examples using Wald and Wilson are shown below with and without continuity correction.
 
-```{R}
+```{sas}
 #| eval: false
 proc sort data=adcibc;
- by  trt descending resp;
+    by  trt descending resp;
 run;
 
-#without continuity correction
+# without continuity correction
 proc freq data=adcibc order=data;
-  table trt*resp/riskdiff(CL=(wald wilson)); 
+    table trt*resp/riskdiff(CL=(wald wilson)); 
 run;
 
-#with continuity correction
-
+# with continuity correction
 proc freq data=adcibc order=data;
-  table trt*resp/riskdiff(CORRECT CL=(wald wilson)); 
+    table trt*resp/riskdiff(CORRECT CL=(wald wilson)); 
 run;
 ```
 

--- a/SAS/cmh.qmd
+++ b/SAS/cmh.qmd
@@ -14,13 +14,12 @@ When the design of the contingency table is 2 x 2 x K (i.e, X == 2 levels, Y == 
 
 Below is the syntax to conduct a CMH analysis in SAS:
 
-```{r}
+```{sas}
 #| eval: false
-Proc freq data = filtered_data; 
-tables K * X * Y / cmh; 
-* the order of K, X, and Y appearing on the line is important!;
+proc freq data = filtered_data; 
+    tables K * X * Y / cmh; 
+    * the order of K, X, and Y appearing on the line is important!;
 run; 
-
 ```
 
 ## Data used
@@ -31,10 +30,10 @@ The adcibc data described [here](https://psiaims.github.io/CAMIS/R/cmh.html) is 
 
 The code used is always the same, however, we can limit the number of levels in each example to show a 2x2x2 case, 2x3xK case etc.
 
-```{r}
+```{sas}
 #| eval: false
-Proc freq data = adcibc; 
-tables agegr1 * trtp *  sex / cmh;  
+proc freq data = adcibc; 
+    tables agegr1 * trtp *  sex / cmh;  
 run;
 ```
 
@@ -70,11 +69,11 @@ Risk differences within each strata can be obtained by adding the riskdiff optio
 
 The individual treatment comparisons within strata can be useful to explore if the treatment effect is in the same direction and size for each strata, such as to determine if pooling them is in fact sensible.
 
-```{r}
+```{sas}
 #| eval: false
-#Default method is: Wald asymptotic confidence limits 
-Proc freq data = adcibc (where=(trtpn ne 54 and agegr1 ne ">80")); 
-tables  agegr1 * trtp *  sex / cmh riskdiff; 
+# Default method is: Wald asymptotic confidence limits 
+proc freq data = adcibc (where=(trtpn ne 54 and agegr1 ne ">80")); 
+    tables  agegr1 * trtp *  sex / cmh riskdiff; 
 run; 
 ```
 
@@ -84,14 +83,17 @@ run;
 #| out-width: 50%
 knitr::include_graphics("../images/cmh/saspage_output3.png")
 ```
-Note above that exact CI's are not output for the difference betweeen the treatments.  You can request SAS output other CI methods as shown below.  This outputs the risk difference between the treatments and 95% CI, calculated for each age group strata separately using the Miettinen-Nurminen (score) (MN) method. 
-```{r} 
+
+Note above that exact CI's are not output for the difference betweeen the treatments. You can request SAS output other CI methods as shown below. This outputs the risk difference between the treatments and 95% CI, calculated for each age group strata separately using the Miettinen-Nurminen (score) (MN) method.
+
+```{sas}
 #| eval: false
-#You can change the confidence limits derivation using (cl=xxx) option
-Proc freq data = adcibc (where=(trtpn ne 54 and agegr1 ne "\>80")); 
-tables agegr1 * trtp * sex / cmh riskdiff(cl=mn);
+# You can change the confidence limits derivation using (cl=xxx) option
+proc freq data = adcibc (where=(trtpn ne 54 and agegr1 ne "\>80")); 
+    tables agegr1 * trtp * sex / cmh riskdiff(cl=mn);
 run;
 ```
+
 ```{r}
 #| echo: false
 #| fig-align: center
@@ -101,17 +103,18 @@ knitr::include_graphics("../images/cmh/saspage_output3b.png")
 
 ### SAS Common error: SAS cannot do a stratified Miettinen-Nurminen (score) method!
 
-Note: you may think by running the following code, that you would be creating a common risk difference using the stratified Miettinen-Nurminen method. However, this is actually performing an unstratified Miettinen-Nurminen (Score) method.  The output contains the same risk differences calculated for each strata separately and then a common risk difference (however this is NOT a stratified approach !!).
-See [SAS guide](https://support.sas.com/documentation/cdl/en/procstat/67528/HTML/default/viewer.htm#procstat_freq_details63.htm) for more detail.
+Note: you may think by running the following code, that you would be creating a common risk difference using the stratified Miettinen-Nurminen method. However, this is actually performing an unstratified Miettinen-Nurminen (Score) method. The output contains the same risk differences calculated for each strata separately and then a common risk difference (however this is NOT a stratified approach !!). See [SAS guide](https://support.sas.com/documentation/cdl/en/procstat/67528/HTML/default/viewer.htm#procstat_freq_details63.htm) for more detail.
 
 See the next section on Common risk differences available in SAS.
-```{r}
+
+```{sas}
 #| eval: false
-#Specifying the Miettinen-Nurminen (score) method 
-Proc freq data = adcibc (where=(trtpn ne 54 and agegr1 ne ">80")); 
-tables  agegr1 * trtp *  sex / cmh riskdiff (common cl=mn); 
+# Specifying the Miettinen-Nurminen (score) method 
+proc freq data = adcibc (where=(trtpn ne 54 and agegr1 ne ">80")); 
+    tables  agegr1 * trtp *  sex / cmh riskdiff (common cl=mn); 
 run; 
 ```
+
 ```{r}
 #| echo: false
 #| fig-align: center
@@ -121,29 +124,28 @@ knitr::include_graphics("../images/cmh/saspage_output3c.png")
 
 ### SAS Common error: Make sure you output the risk difference for the correct level!
 
-Including either column=1 or column=2 tells SAS which is your outcome of interest (ie, often that you want to compare treatment responders and not treatment non-responders!)
-My default it takes the 1st column sorted alphabetically but you can change this as shown below.
+Including either column=1 or column=2 tells SAS which is your outcome of interest (ie, often that you want to compare treatment responders and not treatment non-responders!) My default it takes the 1st column sorted alphabetically but you can change this as shown below.
 
-```{r} 
+```{sas}
 #| eval: false
-Proc freq data = adcibc (where=(trtpn ne 54 and agegr1 ne "\>80")); 
-tables agegr1 * trtp * sex / cmh riskdiff(common column=2);
+proc freq data = adcibc (where=(trtpn ne 54 and agegr1 ne "\>80")); 
+    tables agegr1 * trtp * sex / cmh riskdiff(common column=2);
 run;
 
 ```
 
 ### Common Risk Differences across Strata
 
-Proc freq can calculate estimates of the common risk difference with 95% CIs, calculated using the Mantel-Haenszel and summary score (Miettinen-Nurminen) methods for multiway 2x2 tables.  It can also provide stratified Newcombe confidence intervals using the method by Yan and Su (2010). The stratified Newcombe CIs are constructed from stratified Wilson CIs for the common (overall) row proportions.  See [SAS help](https://support.sas.com/documentation/cdl/en/procstat/67528/HTML/default/viewer.htm#procstat_freq_details63.htm) for more detail.
+Proc freq can calculate estimates of the common risk difference with 95% CIs, calculated using the Mantel-Haenszel and summary score (Miettinen-Nurminen) methods for multiway 2x2 tables. It can also provide stratified Newcombe confidence intervals using the method by Yan and Su (2010). The stratified Newcombe CIs are constructed from stratified Wilson CIs for the common (overall) row proportions. See [SAS help](https://support.sas.com/documentation/cdl/en/procstat/67528/HTML/default/viewer.htm#procstat_freq_details63.htm) for more detail.
 
 Note that SAS (since v9.3M2 / STAT 12.1) PROC FREQ will produce the Miettinen-Nurminen ('MN') score interval for unstratified datasets only. Using 'commonriskdiff' requests risks (binomial proportions) and risk differences for 2x2 tables. But doesn't extend to stratified analysis.
 
 The only known way to have SAS produce stratified Miettinen-Nurminen CIs is to use this publicly available macro: [https://github.com/petelaud/ratesci-sas/tree/main](https://urldefense.com/v3/__https:/github.com/petelaud/ratesci-sas/tree/main__;!!GfteaDio!d_y6BtRjdLQgc_Wr-2-HGeyDSL1v71SvjvEQuVXNjzYaqLVDsEH0DdBLCBE3Q6LGFaTjE4LCjtECNYNFYfMSg4G49w$)
 
-```{r}
+```{sas}
 #| eval: false
-Proc freq data = adcibc (where=(trtpn ne 54 and agegr1 ne ">80")); 
-tables  agegr1 * trtp *  sex / cmh commonriskdiff(CL=SCORE TEST=SCORE); 
+proc freq data = adcibc (where=(trtpn ne 54 and agegr1 ne ">80")); 
+    tables  agegr1 * trtp *  sex / cmh commonriskdiff(CL=SCORE TEST=SCORE); 
 run; 
 
 ```
@@ -154,11 +156,12 @@ run;
 #| out-width: 50%
 knitr::include_graphics("../images/cmh/saspage_output4.png")
 ```
-```{r}
+
+```{sas}
 #| eval: false
-Proc freq data = adcibc (where=(trtpn ne 54 and agegr1 ne ">80")); 
-tables  agegr1 * trtp *  sex / cmh commonriskdiff(CL= newcombe ); 
-run; ); 
+proc freq data = adcibc (where=(trtpn ne 54 and agegr1 ne ">80")); 
+    tables  agegr1 * trtp *  sex / cmh commonriskdiff(CL= newcombe); 
+run;
 ```
 
 ```{r}

--- a/SAS/correlation.qmd
+++ b/SAS/correlation.qmd
@@ -36,10 +36,10 @@ In contrast, if the data set contains missing values for the analysis variables 
 
 ## **Pearson Correlation**
 
-```{r}
+```{sas}
 #| eval: false
 proc corr data=lung pearson;
-var age mealcal;
+    var age mealcal;
 run;
 ```
 
@@ -47,10 +47,10 @@ run;
 
 ## **Spearman Correlation**
 
-```{r}
+```{sas}
 #| eval: false
 proc corr data=lung spearman; 
-var age mealcal; 
+    var age mealcal; 
 run;
 ```
 
@@ -58,10 +58,10 @@ run;
 
 ## Kendall's rank correlation
 
-```{r}
+```{sas}
 #| eval: false
 proc corr data=lung kendall;
-var age mealcal;
+    var age mealcal;
 run;
 ```
 

--- a/SAS/count_data_regression.qmd
+++ b/SAS/count_data_regression.qmd
@@ -1,6 +1,5 @@
 ---
 title: "Poisson and Negative Binomial Regression in SAS"
-output: html_document
 date: last-modified
 date-format: D MMMM, YYYY
 ---
@@ -39,25 +38,23 @@ It is generally good practice to apply the OM option on the lsmeans statement. T
 
 You can use exponential of the maximum likelihood parameter estimate (for treat and age in this example), and the exponential of the Wald 95% Confidence Limits to obtain the odds ratios and 95% CIs. Estimates of the least squares means and CI's for each treatment are output using the lsmeans option. These estimates also have to be back transformed using exponential distribution to get the mean count back onto the original scale. Proc Genmod uses GLM parameterization.
 
-```{r}
+```{sas}
 #| eval: false
-
 ods output ParameterEstimates=ORs lsmeans=lsm;
 proc genmod data=polyps;       
-  class treat (ref="placebo")  ;    
-  model  number = treat age  /  dist=poisson ;
-  lsmeans treat/ cl OM;
+    class treat (ref="placebo");    
+    model  number = treat age  /  dist=poisson;
+    lsmeans treat/ cl OM;
 run; 
 ods output close;
 
-#read in ORs and back transform the estimates (lsm can be done same way)
+# read in ORs and back transform the estimates (lsm can be done same way)
 data bt_or;
-  set ors;
-  OR=exp(estimate);
-  OR_low=exp(lowerwaldcl);
-  OR_high=exp(upperwaldcl);
- run;
-
+    set ors;
+    OR=exp(estimate);
+    OR_low=exp(lowerwaldcl);
+    OR_high=exp(upperwaldcl);
+run;
 ```
 
 ```{r}
@@ -68,17 +65,15 @@ knitr::include_graphics("../images/count_data_regression/poisson1.png")
 knitr::include_graphics("../images/count_data_regression/poisson2.png")
 ```
 
-
 Back transformation of the parameter estimates and 95% CIs produces the following results
 
 Lsmean number of polyps (95% CI) on Drug: 9.02 (7.30 - 11.13)
 
-Lsmean  number of polyps (95% CI) on Placebo: 35.10 (31.72-38.84)
+Lsmean number of polyps (95% CI) on Placebo: 35.10 (31.72-38.84)
 
 Odds ratio (95% CI)= 0.2569 (0.2040 - 0.3235)
 
 Hence, patients on Drug have significantly less polyps than those on placebo.
-
 
 ## **Example: negative binomial in SAS**
 
@@ -86,26 +81,24 @@ In SAS, we can use proc genmod to perform negative binomial regression. The belo
 
 Model parameterization is very similar to poisson
 
-```{r}
+```{sas}
 #| eval: false
-
 ods output ParameterEstimates=ORs lsmeans=lsm;
-  proc genmod data=polyps; 
-  class treat (ref="placebo")  ; 
-  model  number = treat age  /  dist=negbin link=log ;
-  lsmeans treat/ cl OM;
+proc genmod data=polyps; 
+    class treat (ref="placebo"); 
+    model  number = treat age  /  dist=negbin link=log;
+    lsmeans treat/ cl OM;
 run;
 
 ods output close;
 
-
-#read in lsmeans and back transform the estimates (ORs can be done same way)
+# read in lsmeans and back transform the estimates (ORs can be done same way)
 data bt_lsm;
-  set lsm;
-  lsmean_count=exp(estimate);
-  mean_low=exp(lower);
-  mean_high=exp(upper);
- run;
+    set lsm;
+    lsmean_count=exp(estimate);
+    mean_low=exp(lower);
+    mean_high=exp(upper);
+run;
 ```
 
 ```{r}
@@ -120,13 +113,11 @@ Back transformation of the parameter estimates and 95% CIs produces the followin
 
 Lsmean number of polyps (95% CI) on Drug: 8.97 (5.18 - 15.53)
 
-Lsmean  number of polyps (95% CI) on Placebo: 35.24 (22.12-56.13)
+Lsmean number of polyps (95% CI) on Placebo: 35.24 (22.12-56.13)
 
 Odds ratio Drug/Placebo (95% CI)= 0.2546 (0.1232 - 0.5259)
 
 Hence, patients on Drug have significantly less polyps than those on placebo.
-
- 
 
 # References
 

--- a/SAS/jonchkheere_terpstra.qmd
+++ b/SAS/jonchkheere_terpstra.qmd
@@ -12,20 +12,22 @@ The JT test is particularly well-suited for dose-response or trend analysis with
 
 To request Jonckheere-Terpstra test, specify the **JT** option in the Table statement like below:
 
-```{r}
+```{sas}
 #| eval: false
-Proc freq; table Var1 * Var2 / JT ; Quit;
+proc freq; 
+    table Var1 * Var2 / JT; 
+Quit;
 ```
 
 The JT option in the TABLES statement provides the Jonckheere-Terpstra test.
 
-PROC FREQ also provides exact p-values for the Jonckheere-Terpstra test. You can request the exact test by specifying the **JT** option in the EXACT statement.$^{[3]}$ 
+PROC FREQ also provides exact p-values for the Jonckheere-Terpstra test. You can request the exact test by specifying the **JT** option in the EXACT statement.$^{[3]}$
 
 ## Data used 1
 
 This dataset has been generated using example data which aligned with the specifications outlined in the section on the Jonckheere–Terpstra test from reference \[5\]. It represents the duration of hospital stays for a randomly selected group of patients across three distinct ICU departments: cardiothoracic, medical, and neurosurgical.
 
-```{r}
+```{sas}
 #| eval: false
 data ICU_Stay;
     input ICU $ Stay;
@@ -50,6 +52,7 @@ Neurosurgical 14
 Neurosurgical 11
 ;
 run;
+
 proc sort data=ICU_Stay;
     by ICU Stay;
 run;
@@ -59,12 +62,11 @@ run;
 
 The code performs a frequency analysis on the 'ICU_Stay' dataset, examining the relationship between 'ICU' and 'Stay' variables. It applies the Jonckheere-Terpstra test using JT option to identify trends in the ordered categorical 'Stay' variable. The output is streamlined by omitting percentages and totals for columns and rows with the 'nopercent nocol norow' options, emphasizing the Jonckheere-Terpstra test outcomes.
 
-```{r}
+```{sas}
 #| eval: false
 proc freq data=ICU_Stay; 
-  table ICU * Stay / JT nopercent nocol norow; 
+    table ICU * Stay / JT nopercent nocol norow; 
 run;
-
 ```
 
 ## Test Result 1
@@ -77,11 +79,11 @@ Comparing this with a standard Normal distribution gives a P value of 0.005, ind
 
 This dataset incorporates illustrative data extracted from reference \[3\]. It encapsulates the responses of subjects randomly assigned to one of four treatment arms: placebo, low dosage(20mg), medium dosage(60mg), and high dosage(180mg). The variable of interest is a continuous measure. The variable 'groupn' is used to provide an order of 'group'.
 
-```{r}
+```{sas}
 #| eval: false
 data contin;
-input groupn group $  subject response;
-cards;
+    input groupn group $  subject response;
+    cards;
 0 Placebo 01 27
 0 Placebo 02 28
 0 Placebo 03 27
@@ -114,7 +116,7 @@ run;
 
 The code is performing a Jonckheere-Terpstra trend test on a continuous 'response' variable, categorized by a 'group' variable, using the 'proc freq' procedure. The analysis is applied to the dataset named 'contin'. The result is presented with a title "Jonckheere-Terpstra Trend Test for Continuous Data", indicating the specific nature of the test being conducted. The 'JT' option is used to specify the Jonckheere-Terpstra test.
 
-```{SAS}
+```{sas}
 #| eval: false
 proc freq data=contin; 
     tables group * response/JT; 
@@ -129,14 +131,15 @@ run;
 There is a significant trend across different groups in the response gives a P value of \<.0001.
 
 ## EXACT Options
+
 With EXACT statement, the exact version and it Monte Carlo approximation can be also conducted. However, it should be noted that the exact test, i.e., a permuation test takes a long time to compelete the task even for a small dataset.
 
-```{SAS}
+```{sas}
 #| eval: false
 proc freq data = inds;
-  title "Asymptotic p-value calculation";
-  table ICU * Stay / jt;
-  ods output JTTest = o_jt;
+    title "Asymptotic p-value calculation";
+    table ICU * Stay / jt;
+    ods output JTTest = o_jt;
 run;
 
 proc freq data = inds;
@@ -147,8 +150,6 @@ proc freq data = inds;
 run;
 
 ```
-
-
 
 ## Conclusion
 

--- a/SAS/kruskal_wallis.qmd
+++ b/SAS/kruskal_wallis.qmd
@@ -6,11 +6,11 @@ title: "Kruskal Wallis SAS"
 
 The Kruskal-Wallis test is a non-parametric equivalent to the one-way ANOVA. For this example, the data used is a subset of R's datasets::iris, testing for difference in sepal width between species of flower. This data was subset in R and input manually to SAS with a data step.
 
-```{r}
+```{sas}
 #| eval: false
 data iris_sub;
-	input Species $ Sepal_Width;
-	datalines;
+	  input Species $ Sepal_Width;
+	  datalines;
 setosa 3.4
 setosa 3.0
 setosa 3.4
@@ -37,12 +37,12 @@ run;
 
 The Kruskal-Wallis test can be implemented in SAS using the NPAR1WAY procedure with WILCOXON option. Below, the test is defined with the indicator variable (Species) by the CLASS statement, and the response variable (Sepal_Width) by the VAR statement. Adding the EXACT statement outputs the exact p-value in addition to the asymptotic result. The null hypothesis is that the samples are from identical populations.
 
-```{r}
+```{sas}
 #| eval: false
 proc npar1way data=iris_sub wilcoxon;
-class Species;
-var Sepal_Width;
-exact;
+    class Species;
+    var Sepal_Width;
+    exact;
 run;
 ```
 

--- a/SAS/linear-regression.qmd
+++ b/SAS/linear-regression.qmd
@@ -1,21 +1,22 @@
 ---
 title: "Linear Regression"
-output: html_document
 date: last-modified
 date-format: D MMMM, YYYY
 ---
 
 To demonstrate the use of linear regression we examine a dataset that illustrates the relationship between Height and Weight in a group of 237 teen-aged boys and girls. The dataset is available at (../data/htwt.csv) and is imported to sas using proc import procedure.
- 
+
 ### Descriptive Statistics
 
 The first step is to obtain the simple descriptive statistics for the numeric variables of htwt data, and one-way frequencies for categorical variables. This is accomplished by employing proc means and proc freq procedures There are 237 participants who are from 13.9 to 25 years old. It is a cross-sectional study, with each participant having one observation. We can use this data set to examine the relationship of participants' height to their age and sex.
 
-```{r}
+```{sas}
 #| eval: false
 proc means data=htwt;
 run;
+```
 
+```default
                     Descriptive Statistics for HTWT Data Set                  
                              The MEANS Procedure
 
@@ -25,15 +26,16 @@ AGE       AGE     237    16.4430380     1.8425767    13.9000000    25.0000000
 HEIGHT    HEIGHT  237    61.3645570     3.9454019    50.5000000    72.0000000
 WEIGHT    WEIGHT  237   101.3080169    19.4406980    50.5000000   171.5000000
 ----------------------------------------------------------------------------
-
 ```
 
-```{r}
+```{sas}
 #| eval: false
 proc freq data=htwt;
-tables sex;
+    tables sex;
 run;
+```
 
+```default
     Oneway Frequency Tabulation for Sex for HTWT Data Set                    
                     The FREQ Procedure
 
@@ -46,28 +48,32 @@ m           126           53.16           237       100.00
 
 In order to create a regression model to demonstrate the relationship between age and height for females, we first need to create a flag variable identifying females and an interaction variable between age and female gender flag.
 
-```{r}
+```{sas}
 #| eval: false
 data htwt2;
   set htwt;
   if sex="f" then female=1;
   if sex="m" then female=0; 
- 
+
   *model to demonstrate interaction between female gender and age;
   fem_age = female * age;  
 run;
 ```
+
 ### Regression Analysis
+
 Next, we fit a regression model, representing the relationships between gender, age, height and the interaction variable created in the datastep above. We again use a where statement to restrict the analysis to those who are less than or equal to 19 years old. We use the clb option to get a 95% confidence interval for each of the parameters in the model. The model that we are fitting is ***height = b0 + b1 x female + b2 x age + b3 x fem_age + e***
 
-```{r}
+```{sas}
 #| eval: false
 proc reg data=htwt2;
-  where age <=19;
-  model height = female age fem_age / clb;
-run; quit;
+    where age <=19;
+    model height = female age fem_age / clb;
+run; 
+quit;
+```
 
-
+```default
                         Number of Observations Read         219
                         Number of Observations Used         219
 
@@ -87,8 +93,7 @@ run; quit;
 
 We examine the parameter estimates in the output below.
 
-```{r}
-#| eval: false
+```default
                             Parameter Estimates
                             Parameter       Standard
        Variable     DF       Estimate          Error    t Value    Pr > |t|       95% Confidence Limits

--- a/SAS/logistic-regr.qmd
+++ b/SAS/logistic-regr.qmd
@@ -1,6 +1,5 @@
 ---
 title: "Logistic Regression in SAS"
-output: html_document
 date: last-modified
 date-format: D MMMM, YYYY
 ---
@@ -37,24 +36,30 @@ Below we are fitting trt01pn and sex as categorical variables, age, ph_ecog2 and
 
 You can use exponential of the maximum likelihood parameter estimate and the exponential of the Wald 95% Confidence Limits to obtain the odds ratios and 95% CIs. Proc Genmod uses GLM parameterization.
 
-```{r}
+```{sas}
 #| eval: false
 Example data: . = missing, trt01pn (1 or 2), sex (1 or 2), ph_ecog2 (0,1,2,3)
 wt_gain (1=gain, 0=no gain)
+```
 
+```default
 wt_gain   trt01pn  age   sex    ph_ecog2   meal_caln
 -----------------------------------------------------------------------------
 .         1        74    1       1          1175
 0         1        68    2       0          1225
 1         2        60    1       2           .
+```
 
-
+```{sas}
+#| eval: false
 proc genmod data=lung;       
-  class trt01pn (ref="1") sex (ref="1")  ;    
-  model wt_gain (event="1") = trt01pn age sex ph_ecog2 meal_caln / 
+    class trt01pn (ref="1") sex (ref="1");    
+    model wt_gain (event="1") = trt01pn age sex ph_ecog2 meal_caln / 
         dist=bin link=logit;
-run; 
+run;
+```
 
+```default
 Class Level Information
 Class     Levels      Values
 -----------------------------------------------------------------------------
@@ -101,13 +106,15 @@ Proc Logistic is often preferred above Proc Genmod as it outputs the Odds Ratios
 
 NOTE: that the 95% confidence limits are being calculated using the Wald method. This assumes symmetric intervals around the maximum likelihood estimate using a normal distribution assumption (MLE +/-1.96\* SE). Alternative confidence interval estimation methods exist such as the profile likelihood method but SAS does not calculate these.
 
-```{r}
+```{sas}
 #| eval: false
 proc logistic data=lung;  
     class trt01pn (ref="1") sex (ref="1") /param=glm;
     model  wt_gain(event="1") = trt01pn age sex ph_ecog2 meal_caln;
 run;
+```
 
+```default
 Response Profile
 Ordered value     wt_gain         Total Frequency
 -----------------------------------------------------------------------------
@@ -154,18 +161,18 @@ sex     2 vs 1   2.298             1.103   4.787
 ph_ecog          0.686             0.409   1.151  
 meal_cal         1.001             1.000   1.002 
 ----------------------------------------------------------------------------
-
-
 ```
 
 ## **Model Comparison**
 
 To compare two logistic models, the -2 \* Log Likelihood from each model can be compared against a $\chi^2$-distribution with degrees of freedom calculated using the difference in the two models' parameters.
 
-```{r}
+```{sas}
 #| eval: false
 Model 1:  model  wt_gain(event="1") = trt01pn age sex ph_ecog2 meal_caln;
+```
 
+```default
 Model Fit Statistics
 Criterion   Intercept Only     Intercept and Covariates       
 --------------------------------------------------------
@@ -173,7 +180,7 @@ AIC         204.355            202.460
 SC          207.491            221.274
 -2 Log L    202.355            190.460   
 --------------------------------------------------------
-  
+
 Model 2:  model  wt_gain(event="1") = trt01pn sex ph_ecog2 meal_caln;
 
 Model Fit Statistics
@@ -183,20 +190,22 @@ AIC         204.355            200.798
 SC          207.491            216.477
 -2 Log L    202.355            190.798   
 --------------------------------------------------------
-```
 
 190.460 - 190.798 = -0.338 which using a $\chi^2$-distribution corresponds to p=0.5606
+```
 
 SAS also allows us to fit forward or backwards stepwise selection. Below we specify to stop when we have 4 variables left in the model. This is not commonly done in practice but is included to highlight the difference in using a selection procedure compared to doing the difference betweeen the -2 \* log likelihood models using a $\chi^2$-distribution.
 
-```{r}
+```{sas}
 #| eval: false
 proc logistic data=lung;  
     class trt01pn (ref="1") sex (ref="1") /param=glm;
     model  wt_gain(event="1") = trt01pn age sex ph_ecog2 meal_caln/ 
-           selection=backward stop=4;
-run;  
+            selection=backward stop=4;
+run;
+```
 
+```default
 Step 1: Effect age is removed
 Summary of Backward Elimination
 Step   Effect Removed   DF     Number In     Wald Chi-Square   Pr>ChiSq
@@ -223,13 +232,15 @@ This is the SAS default such that if you do not specify the `/param` option, SAS
 
 With the EFFECT option, dose_id has 3 levels, and so needs 2 design variables (β1 and β2). Sex has 2 levels so uses just 1 design variable (β1). For dose_id, the reference level (Placebo) is given values of "-1" for both of the β1 and β2 parameters. General model: Y= α + β1x1 + β2x1 {+β3x3} etc, representing each parameter in the model.
 
-```{r}
+```{sas}
 #| eval: false
 proc logistic data=lung;  
     class dose_id (ref="3") sex (ref="1") /param=effect;
     model  wt_gain(event="1") = dose_id age sex ph_ecog2 meal_caln;
 run;
+```
 
+```default
 Class Level Information
 Class       Value            Design Variables
 --------------------------------------------------------
@@ -242,8 +253,11 @@ dose_id      1                1           0
 SEX          1               -1
              2                1
 --------------------------------------------------------
+```
 
 If we want to estimate the effect of treatment (ignoring the other covariates), the Class Level Information can be translated into the table below, which is then used to form contrast statements.
+
+```default
 α is the intercept, and β1 and β2 (including the sign +/-) are from the design variables above.
                               
 Dose_id       Effect          
@@ -252,51 +266,68 @@ Dose_id       Effect
 20mg Active   Y = α + β2          
 Placebo       Y = α - β1 - β2    
 ------------------------------
-  
+```
+
 To compare 10mg Active vs Placebo, we would do the following:
- (α + β1 ) - (α - β1 - β2)
+
+```default
+(α + β1 ) - (α - β1 - β2)
 = 2 β1 + β2  
 = 2 β1 + 1 β2
+```
 
 This equates to a contrast statement as follows:
+
+```{sas}
+#| eval: false
 proc logistic data=lung;  
     class dose_id (ref="3") sex (ref="1") /param=effect;
     model  wt_gain(event="1") = dose_id age sex ph_ecog2 meal_caln;
     CONTRAST "10mg vs. Placebo" dose_id 2 1 / e; 
 run;
-  
+```
+
 To compare the average of (10mg Active and 20mg Active) vs Placebo, we would do the following:
+
+```default
 ((α + β1 + α + β2 ) /2 ) - (α - β1 - β2)
 = α + 0.5 β1 + 0.5 β2 - α + β1 + β2  
 = 1.5 β1 + 1.5 β2
+```
 
 This equates to a contrast statement as follows:
+
+```{sas}
+#| eval: false
 proc logistic data=lung;  
     class dose_id (ref="3") sex (ref="1") /param=effect;
     model  wt_gain(event="1") = dose_id age sex ph_ecog2 meal_caln;
     CONTRAST "Active (10mg + 20mg) vs. Placebo" dose_id 1.5 1.5 / e; 
 run;
+```
 
 As you can see, these contrasts are not very intuitive and hence it is not reccomended to use the default SAS option of /param=effect, since its easy to end up with the wrong contrasts.
 
+```default
 Contract Test Results
 Contrast                           DF        Wald Chi-Square      Pr>ChiSq
 --------------------------------------------------------
 Active (10mg +20mg) vs Placebo     1          1.1610               0.2813
-              
 ```
 
 ### CLASS X Y Z /PARAM=glm
 
 Now let's look at the `param=glm` option. GLM parameterization has a design variable for each level of a parameter. Hence for dose with 3 levels, we have 3 design variables (β1, β2 and β3).
 
-```{r}
+```{sas}
 #| eval: false
 proc logistic data=lung;  
     class dose_id (ref="3") sex (ref="1") /param=glm;
     model  wt_gain(event="1") = dose_id age sex ph_ecog2 meal_caln;
 run;
+```
 
+```default
 Class Level Information
 Class       Value            Design Variables
 --------------------------------------------------------
@@ -309,8 +340,11 @@ dose_id      1                1           0       0
 SEX          1                1           0
              2                0           1
 --------------------------------------------------------
+```
 
 If we want to estimate the effect of treatment (ignoring the other covariates), the Class Level Information can be translated into the table below, which is then used to form contrast statements.
+
+```default
 α is the intercept, and β1 and β2 and β3 (including the sign +/-) are from the design variables above.
                               
 Dose_id       Effect          
@@ -319,35 +353,50 @@ Dose_id       Effect
 20mg Active   Y = α + β2          
 Placebo       Y = α - β3    
 --------------------------------------------------------
-  
+```
+
 To compare 10mg Active vs Placebo, we would do the following:
- (α + β1 ) - (α - β3)
+
+```default
+(α + β1 ) - (α - β3)
 =  β1 - β3  
 = 1 β1 - 1 β3
+```
 
 This equates to a contrast statement as follows:
+
+```{sas}
+#| eval: false
 proc logistic data=lung;  
     class dose_id (ref="3") sex (ref="1") /param=glm;
     model  wt_gain(event="1") = dose_id age sex ph_ecog2 meal_caln;
     CONTRAST "10mg vs. Placebo" trt 1 -1 / e; 
 run;
-  
+```
 As you can see, this contrast is much more intuitive. If you want to compare the effect of Active (10mg) compared to placebo,  you take the effect of 10mg and subtract the effect of placebo !
 
 To compare the average of (10mg Active and 20mg Active) vs Placebo, we would do the following:
-((α + β1 + α + β2)/2 - (α + β3) 
+
+```default
+(α + β1 + α + β2)/2 - (α + β3) 
 = α + 0.5 β1 + 0.5 β2 - α - β3 
 = 0.5 β1 + 0.5 β2 - β3
+```
 
 This equates to a contrast statement as follows:
+
+```{sas}
+#| eval: false
 proc logistic data=lung;  
     class dose_id (ref="3") sex (ref="1") /param=glm;
     model  wt_gain(event="1") = dose_id age sex ph_ecog2 meal_caln;
 CONTRAST "Active (10mg + 20mg) vs. Placebo (1)" trt 0.5 0.5 -1 / e; 
 run;
+```
 
-As you can see, this contrast is much more intuitive. If you want to compare the average of Active (10mg + 20mg) compared to placebo,  you take half the effect of 10mg plus half the effect of 20mg and substract the effect of placebo !
-  
+As you can see, this contrast is much more intuitive. If you want to compare the average of Active (10mg + 20mg) compared to placebo,  you take half the effect of 10mg plus half the effect of 20mg and substract the effect of placebo!
+
+```default
 Contract Test Results
 Contrast                           DF        Wald Chi-Square      Pr>ChiSq
 --------------------------------------------------------
@@ -358,13 +407,15 @@ Active (10mg +20mg) vs Placebo     1          1.1610               0.2813
 
 Now let's look at the `param=ref` option. Similar to param=effect, ref parameterization uses 1 less design variable compared to the number of levels each parameter has, but the parameterization is different. For dose with 3 levels, we have 2 design variables (β1 and β2).
 
-```{r}
+```{sas}
 #| eval: false
 proc logistic data=lung;   
-class dose_id (ref="3") sex (ref="1") /param=ref;
-model  wt_gain(event="1") = dose_id age sex ph_ecog2 meal_caln;
+    class dose_id (ref="3") sex (ref="1") /param=ref;
+    model  wt_gain(event="1") = dose_id age sex ph_ecog2 meal_caln;
 run;
+```
 
+```default
 Class Level Information
 Class       Value            Design Variables
 --------------------------------------------------------
@@ -377,8 +428,11 @@ dose_id      1                1           0
 SEX          1                0           
              2                1           
 --------------------------------------------------------
+```
 
 If we want to estimate the effect of treatment (ignoring the other covariates), the Class Level Information can be translated into the table below, which is then used to form contrast statements.
+
+```default
 α is the intercept, and β1 and β2 and β3 (including the sign +/-) are from the design variables above.
                               
 Dose_id       Effect          
@@ -387,32 +441,46 @@ Dose_id       Effect
 20mg Active   Y = α + β2          
 Placebo       Y = α     
 --------------------------------------------------------
-  
+```
+
 To compare 10mg Active vs Placebo, we would do the following:
- (α + β1 ) - (α )
-=  β1  
+
+```default
+(α + β1 ) - (α ) =  β1  
+```
 
 This equates to a contrast statement as follows:
+```{sas}
+#| eval: false
 proc logistic data=lung;  
     class dose_id (ref="3") sex (ref="1") /param=glm;
     model  wt_gain(event="1") = dose_id age sex ph_ecog2 meal_caln;
     CONTRAST "10mg vs. Placebo" trt 1  / e; 
 run;
-  
+```
+
 To compare the average of (10mg Active and 20mg Active) vs Placebo, we would do the following:
-((α + β1 + α + β2)/2 -  α  
+
+```default
+(α + β1 + α + β2)/2 -  α  
 = α + 0.5 β1 + 0.5 β2 - α  
-= 0.5 β1 + 0.5 β2 
+= 0.5 β1 + 0.5 β2
+```
 
 This equates to a contrast statement as follows:
+
+```{sas}
+#| eval: false
 proc logistic data=lung;  
     class dose_id (ref="3") sex (ref="1") /param=glm;
     model  wt_gain(event="1") = dose_id age sex ph_ecog2 meal_caln;
 CONTRAST "Active (10mg + 20mg) vs. Placebo (1)" trt 0.5 0.5  / e; 
 run;
+```
 
-Again this is less intuitive than the param=glm parameterization,  but the same results are obtained.
-  
+Again this is less intuitive than the param=glm parameterization, but the same results are obtained.
+
+```default
 Contract Test Results
 Contrast                           DF        Wald Chi-Square      Pr>ChiSq
 --------------------------------------------------------
@@ -423,14 +491,16 @@ Active (10mg +20mg) vs Placebo     1          1.1610               0.2813
 
 The Contrast statement, only outputs the p-value for the contrast, but it is common to also require an estimate of the difference between the treatments, with associated 95% CI. You can do this by changing `contrast` to an `estimate` statement. Note that the parameterization of the contrast remains the same as when using a contrast statement as shown below. These estimates and 95% CI's can be back transformed to give you the Odds ratio of the contrast and associated 95% CI. The estimate coefficients table should be checked for accuracy versus the contrast you are trying to do.
 
-```{r}
+```{sas}
 #| eval: false
 proc logistic data=lung;
-class dose_id (ref="3") sex (ref="1") /param=glm;
-model wt_gain(event="1") = dose_id age sex ph_ecog2 meal_caln; 
-Estimate "Active (10mg + 20mg) vs. Placebo (1)" dose_id 0.5 0.5 -1 / e cl; 
+    class dose_id (ref="3") sex (ref="1") /param=glm;
+    model wt_gain(event="1") = dose_id age sex ph_ecog2 meal_caln; 
+    Estimate "Active (10mg + 20mg) vs. Placebo (1)" dose_id 0.5 0.5 -1 / e cl; 
 run;
+```
 
+```default
 Estimate Coefficients
 Parameter   dose_id    sex    Row1
 --------------------------------------------------------
@@ -438,7 +508,7 @@ dose_id 1   1                 0.5
 dose_id 2   2                 0.5 
 dose_id 3   3                 -1
 --------------------------------------------------------
-  
+
 Estimate
 Label      estimate   Std Err   Z value   Pr>|z| Alpha  Lower  Upper
 --------------------------------------------------------------------------

--- a/SAS/manova.qmd
+++ b/SAS/manova.qmd
@@ -8,48 +8,48 @@ This example employs multivariate analysis of variance (MANOVA) to measure diffe
 
 For each of 26 samples of pottery, the percentages of oxides of five metals are measured. The following statements create the data set and invoke the GLM procedure to perform a one-way MANOVA. Additionally, it is of interest to know whether the pottery from one site in Wales (Llanederyn) differs from the samples from other sites; a CONTRAST statement is used to test this hypothesis.
 
-```{r}
+```{sas}
 #| eval: false
-    #Example code
-    title "Romano-British Pottery";
-   data pottery;
-      input Site $12. Al Fe Mg Ca Na;
-      datalines;
-   Llanederyn   14.4 7.00 4.30 0.15 0.51
-   Llanederyn   13.8 7.08 3.43 0.12 0.17
-   Llanederyn   14.6 7.09 3.88 0.13 0.20
-   Llanederyn   11.5 6.37 5.64 0.16 0.14
-   Llanederyn   13.8 7.06 5.34 0.20 0.20
-   Llanederyn   10.9 6.26 3.47 0.17 0.22
-   Llanederyn   10.1 4.26 4.26 0.20 0.18
-   Llanederyn   11.6 5.78 5.91 0.18 0.16
-   Llanederyn   11.1 5.49 4.52 0.29 0.30
-   Llanederyn   13.4 6.92 7.23 0.28 0.20
-   Llanederyn   12.4 6.13 5.69 0.22 0.54
-   Llanederyn   13.1 6.64 5.51 0.31 0.24
-   Llanederyn   12.7 6.69 4.45 0.20 0.22
-   Llanederyn   12.5 6.44 3.94 0.22 0.23
-   Caldicot     11.8 5.44 3.94 0.30 0.04
-   Caldicot     11.6 5.39 3.77 0.29 0.06
-   IslandThorns 18.3 1.28 0.67 0.03 0.03
-   IslandThorns 15.8 2.39 0.63 0.01 0.04
-   IslandThorns 18.0 1.50 0.67 0.01 0.06
-   IslandThorns 18.0 1.88 0.68 0.01 0.04
-   IslandThorns 20.8 1.51 0.72 0.07 0.10
-   AshleyRails  17.7 1.12 0.56 0.06 0.06
-   AshleyRails  18.3 1.14 0.67 0.06 0.05
-   AshleyRails  16.7 0.92 0.53 0.01 0.05
-   AshleyRails  14.8 2.74 0.67 0.03 0.05
-   AshleyRails  19.1 1.64 0.60 0.10 0.03
-   ;
-   run;
-   
-   proc glm data=pottery;
-      class Site;
-      model Al Fe Mg Ca Na = Site;
-      contrast 'Llanederyn vs. the rest' Site 1 1 1 -3;
-      manova h=_all_ / printe printh;
-   run;
+# Example code
+title "Romano-British Pottery";
+data pottery;
+  input Site $12. Al Fe Mg Ca Na;
+  datalines;
+    Llanederyn   14.4 7.00 4.30 0.15 0.51
+    Llanederyn   13.8 7.08 3.43 0.12 0.17
+    Llanederyn   14.6 7.09 3.88 0.13 0.20
+    Llanederyn   11.5 6.37 5.64 0.16 0.14
+    Llanederyn   13.8 7.06 5.34 0.20 0.20
+    Llanederyn   10.9 6.26 3.47 0.17 0.22
+    Llanederyn   10.1 4.26 4.26 0.20 0.18
+    Llanederyn   11.6 5.78 5.91 0.18 0.16
+    Llanederyn   11.1 5.49 4.52 0.29 0.30
+    Llanederyn   13.4 6.92 7.23 0.28 0.20
+    Llanederyn   12.4 6.13 5.69 0.22 0.54
+    Llanederyn   13.1 6.64 5.51 0.31 0.24
+    Llanederyn   12.7 6.69 4.45 0.20 0.22
+    Llanederyn   12.5 6.44 3.94 0.22 0.23
+    Caldicot     11.8 5.44 3.94 0.30 0.04
+    Caldicot     11.6 5.39 3.77 0.29 0.06
+    IslandThorns 18.3 1.28 0.67 0.03 0.03
+    IslandThorns 15.8 2.39 0.63 0.01 0.04
+    IslandThorns 18.0 1.50 0.67 0.01 0.06
+    IslandThorns 18.0 1.88 0.68 0.01 0.04
+    IslandThorns 20.8 1.51 0.72 0.07 0.10
+    AshleyRails  17.7 1.12 0.56 0.06 0.06
+    AshleyRails  18.3 1.14 0.67 0.06 0.05
+    AshleyRails  16.7 0.92 0.53 0.01 0.05
+    AshleyRails  14.8 2.74 0.67 0.03 0.05
+    AshleyRails  19.1 1.64 0.60 0.10 0.03
+;
+run;
+
+proc glm data=pottery;
+    class Site;
+    model Al Fe Mg Ca Na = Site;
+    contrast 'Llanederyn vs. the rest' Site 1 1 1 -3;
+    manova h=_all_ / printe printh;
+run;
 ```
 
 After the summary information (1), PROC GLM produces the univariate analyses for each of the dependent variables (2-6). These analyses show that sites are significantly different for all oxides individually. You can suppress these univariate analyses by specifying the NOUNI option in the MODEL statement.

--- a/SAS/mcnemar.qmd
+++ b/SAS/mcnemar.qmd
@@ -10,10 +10,10 @@ To demonstrate McNemar's test in SAS, data concerning the presence or absence of
 
 Testing for a significant difference in cold symptoms between ages, using McNemar's test in SAS, can be performed as below. The AGREE option is stated within the FREQ procedure to produce agreement tests and measures, including McNemar's test.
 
-```{r}
+```{sas}
 #| eval: false
 proc freq data=colds;
-  tables age12*age14 / agree;
+    tables age12*age14 / agree;
 run;
 ```
 

--- a/SAS/mi_mar_regression.qmd
+++ b/SAS/mi_mar_regression.qmd
@@ -4,15 +4,16 @@ title: "Multiple Imputaton: Linear Regression in SAS"
 
 ## Input dataset preparation before multiple imputation
 
-1.  Prepare a subset of the analysis dummy dataset, details as below: 
-  - `USUBJID` (length 4): Subject ID. 
-  - `SEX1N`: Sex A random integer between 0 and 1 representing a binary variable (perhaps gender). 
-  - `AVISITN`: Visit number (1 to 5 for each subject). 
-  - `AVAL`: A random value between 1 and 2, with a random 10% chance of being missing.
+1.  Prepare a subset of the analysis dummy dataset, details as below:
+
+-   `USUBJID` (length 4): Subject ID.
+-   `SEX1N`: Sex A random integer between 0 and 1 representing a binary variable (perhaps gender).
+-   `AVISITN`: Visit number (1 to 5 for each subject).
+-   `AVAL`: A random value between 1 and 2, with a random 10% chance of being missing.
 
 As PROC MI requires a horizontal, one record per subject data set. More often than not, the data we impute will come from a vertical ADaM BDS data set. So we need to first transpose the aval with the avisitn as ID (assuming avisitn = 1 to 5),creating transposed variable v1-v5.
 
-```{r}
+```{sas}
 #| eval: false
 data dummy;
     length USUBJID $4;
@@ -28,12 +29,17 @@ data dummy;
     end;
     drop i j;
 run;
-proc sort data=dummy; by usubjid sex1n;run;
+
+proc sort data=dummy; 
+    by usubjid sex1n;
+run;
+
 proc transpose data=dummy out=dummyt(drop=_name_) prefix=v;
     by USUBJID sex1n;
     id avisitn;
     var aval;
 run;
+
 proc print data=dummyt(obs=5);
 run;
 ```
@@ -53,11 +59,11 @@ The pattern can be checked using the following code, missing data pattern could 
 
 -   "Arbitrary" : The missingness of data does not follow any specific order or predictable sequence. Data can be missing at random points without a discernible pattern.
 
-```{r}
+```{sas}
 #| eval: false
 ods select MissPattern;
 proc mi data=dummyt nimpute=0;
-var v1 - v5;
+    var v1 - v5;
 run;
 ```
 
@@ -67,17 +73,19 @@ As below figure shows the missingness dose not follow any specific order, obviou
 #| echo: false
 #| fig-align: center
 #| out-width: 100%
-knitr::include_graphics("../images/mi_mar_linear_sas/mi_mar_reg_missing_pattern.PNG")
+knitr::include_graphics(
+  "../images/mi_mar_linear_sas/mi_mar_reg_missing_pattern.PNG"
+)
 ```
 
 ## FCS Regression for non-monotone missing pattern
 
-```{r}
+```{sas}
 #| eval: false
 proc mi data=dummyt out=outdata nimpute=10 seed=123;
-  class sex1n;
-  var sex1n v1 - v5;
-  fcs reg (v1-v5 /details);
+    class sex1n;
+    var sex1n v1 - v5;
+    fcs reg (v1-v5 /details);
 run;
 ```
 
@@ -108,7 +116,7 @@ knitr::include_graphics("../images/mi_mar_linear_sas/mi_mar_reg_fcs2.PNG")
 
 Let's update above SAS code to generate a dummy dataset with monotone missing pattern
 
-```{r}
+```{sas}
 #| eval: false
 data dummy;
     length USUBJID $4;
@@ -125,17 +133,23 @@ data dummy;
     end;
     drop i miss_start j;
 run;
-proc sort data=dummy; by usubjid sex1n;run;
+
+proc sort data=dummy; 
+    by usubjid sex1n;
+run;
+
 proc transpose data=dummy out=dummyt(drop=_name_) prefix=v;
     by USUBJID sex1n;
     id avisitn;
     var aval;
 run;
+
 proc print data=dummyt(obs=5);
 run;
+
 ods select MissPattern;
 proc mi data=dummyt nimpute=0;
-var v1 - v5;
+    var v1 - v5;
 run;
 ```
 
@@ -143,17 +157,19 @@ run;
 #| echo: false
 #| fig-align: center
 #| out-width: 100%
-knitr::include_graphics("../images/mi_mar_linear_sas/mi_mar_reg_missing_pattern_monotone.PNG")
+knitr::include_graphics(
+  "../images/mi_mar_linear_sas/mi_mar_reg_missing_pattern_monotone.PNG"
+)
 ```
 
 In this case we will use `monotone` statement instead of `FCS` for the imputation, example code as below:
 
-```{r}
+```{sas}
 #| eval: false
 proc mi data=dummyt out=outdata nimpute=10 seed=123;
-  class sex1n;
-  var sex1n v1 - v5;
-  monotone reg (v1-v5 /details);
+    class sex1n;
+    var sex1n v1 - v5;
+    monotone reg (v1-v5 /details);
 run;
 ```
 

--- a/SAS/mmrm.qmd
+++ b/SAS/mmrm.qmd
@@ -8,17 +8,16 @@ title: "MMRM in SAS"
 
 In SAS the following code was used (assessments at `avisitn=0` should also be removed from the response variable):
 
-```{r}
+```{sas}
 #| eval: false
-#| echo: true
 proc mixed data=adlbh;
-  where base ne . and avisitn not in (., 99);
-  class usubjid trtpn(ref="0") avisitn;
-  by paramcd param;
-  model chg=base trtpn avisitn  trtpn*avisitn / solution cl alpha=0.05 ddfm=KR;
-  repeated avisitn/subject=usubjid type=&covar;
-  lsmeans trtpn * avisitn / diff cl slice=avisitn;
-  lsmeans trtpn / diff cl;
+    where base ne . and avisitn not in (., 99);
+    class usubjid trtpn(ref="0") avisitn;
+    by paramcd param;
+    model chg=base trtpn avisitn  trtpn*avisitn / solution cl alpha=0.05 ddfm=KR;
+    repeated avisitn/subject=usubjid type=&covar;
+    lsmeans trtpn * avisitn / diff cl slice=avisitn;
+    lsmeans trtpn / diff cl;
 run;
 ```
 

--- a/SAS/nparestimate.qmd
+++ b/SAS/nparestimate.qmd
@@ -12,12 +12,12 @@ PROC NPAR1WAY provides these estimates in a flexible manner.
 
 # Case study
 
-```{r}
+```{sas}
 #| eval: false
 # Hollander-Wolfe-Chicken Example
-data all ;
-input group $ value ; 
-cards ;
+data all;
+input group $ value; 
+  cards;
 A 1.83
 A 0.50
 A 1.62
@@ -37,36 +37,35 @@ B 1.060
 B 3.140
 B 1.290
 ; 
-run ;
-
+run;
 ```
 
 # Hodges-Lehmann estimate and confidence interval
 
 Hodges-Lehmann estimate and Moses confidence interval for the 2-sample case will be generated when putting HL as an option. The direction of the comparison can be controlled via refclass. If the exact confidence interval is required additionally then the exact statement together with the option HL needs to be defined. The Hodges-Lehmann point estimate and confidence interval can be addressed via the HodgesLehmann option under the ODS statement.
 
-```{r}
+```{sas}
 #| eval: false
-proc npar1way hl (refclass = "B") data = all ;
-   class group ;
-   var value ;
-   exact hl ;
-   ods select HodgesLehmann ;
-run ;
+proc npar1way hl (refclass = "B") data = all;
+    class group;
+    var value;
+    exact hl;
+    ods select HodgesLehmann;
+run;
 ```
 
 # Results
 
 The NPAR1WAY Procedure
 
-```         
+```default
                                            Hodges-Lehmann Estimation                                                
-                                                                                                                    
+
                                         Location Shift (A - B)    0.5600                                            
-                                                                                                                    
+
                                                                    Interval        Asymptotic                       
                    Type                 95% Confidence Limits      Midpoint    Standard Error                       
-                                                                                                                    
+
                    Asymptotic (Moses)     -0.3700      1.1830        0.4065            0.3962                       
                    Exact                  -0.2200      1.0820        0.4310                                         
 ```

--- a/SAS/ranksum.qmd
+++ b/SAS/ranksum.qmd
@@ -12,7 +12,8 @@ To perform a Wilcoxon rank-sum test in SAS, you can use the PROC NPAR1WAY proced
 
 1.  **Create the Dataset**: If there are two groups (smoker and non-smoker) with their respective measurements birth weight, you can input the data as follows:
 
-``` sas
+```{sas}
+#| eval: false
 /* Create dataset */
 data bw;
     input bw  grp $;
@@ -52,17 +53,18 @@ run;
 
 2.  **Perform the Wilcoxon rank-sum Test**: Use the PROC NPAR1WAY procedure to perform the test. The wilcoxon option specifies that you want to perform the Wilcoxon rank-sum test. When computing the asymptotic Wilcoxon two-sample test, PROC NPAR1WAY uses a continuity correction by default. If specify the CORRECT=NO option in the PROC NPAR1WAY statement, the procedure does not use a continuity correction. Typically, we will also want the Hodges-Lehman confidence intervals. To get these you will need to add `hl` to the pro npar1way statement.
 
-``` sas
+```{sas}
+#| eval: false
 /* Perform Wilcoxon rank-sum test - with continuity correction by default*/
 proc npar1way data=BW wilcoxon hl;
-    class grp;
-    var bw;
+    class grp;
+    var bw;
 run;
 
 /* Perform Wilcoxon rank-sum test - without continuity correction*/
 proc npar1way data=BW wilcoxon CORRECT=NO hl;
-    class grp;
-    var bw;
+    class grp;
+    var bw;
 run;
 ```
 
@@ -108,12 +110,13 @@ The correction does not effect the Hodges-Lehman CI. The Location shift is the H
 
 For sufficiently small sample size, the large-sample normal approximation used by the asymptotic Wilcoxon might not be appropriate, so the exact statement is needed.
 
-``` sas
+```{sas}
+#| eval: false
 /* Perform Wilcoxon rank-sum test - with continuity correction by default*/
 proc npar1way data=BW wilcoxon CORRECT=NO hl;
-    class grp;
-    var bw;
-    exact wilcoxon hl;
+    class grp;
+    var bw;
+    exact wilcoxon hl;
 run;
 ```
 

--- a/SAS/rbmi_continuous_joint_SAS.qmd
+++ b/SAS/rbmi_continuous_joint_SAS.qmd
@@ -1,50 +1,52 @@
 ---
-title: "<SAS> <Reference-Based Multiple Imputation (joint modelling): Continuous Data>"
+title: "Reference-Based Multiple Imputation (joint modelling): Continuous Data"
 ---
 
 ## Reference-based multiple imputation (rbmi)
 
 ### Methodology introduction
+
 Reference-based multiple imputation methods have become popular for handling missing data, as well as for conducting sensitivity analyses, in randomized clinical trials. In the context of a repeatedly measured continuous endpoint assuming a multivariate normal model, [Carpenter et al. (2013)](https://www.tandfonline.com/doi/full/10.1080/10543406.2013.834911) proposed a framework to extend the usual MAR-based MI approach by postulating assumptions about the joint distribution of pre- and post-deviation data. Under this framework, one makes qualitative assumptions about how individuals’ missing outcomes relate to those observed in relevant groups in the trial, based on plausible clinical scenarios. Statistical analysis then proceeds using the method of multiple imputation ([Rubin 1976](https://doi.org/10.1093/biomet/63.3.581), [Rubin 1987](https://onlinelibrary.wiley.com/doi/book/10.1002/9780470316696)).
 
 In general, multiple imputation of a repeatedly measured continuous outcome can be done via 2 computational routes ([Roger 2022](https://baselbiometrics.github.io/home/docs/talks/20221208/5_JamesRoger%2020121118.pdf)):
 
-  1. Stepwise: split problem into separate imputations of data at each visit
-  
-      + requires monotone missingness, such as missingness due to withdrawal
-    
-      + conditions on the imputed values at previous visit
-    
-      + Bayesian linear regression problem is much simpler with monotone missing, as one can sample directly using conjugate priors
+1.  Stepwise: split problem into separate imputations of data at each visit
 
-  2. One-step approach (joint modelling): Fit a Bayesian full multivariate normal repeated measures model using MCMC and then draw a sample.
+    -   requires monotone missingness, such as missingness due to withdrawal
+
+    -   conditions on the imputed values at previous visit
+
+    -   Bayesian linear regression problem is much simpler with monotone missing, as one can sample directly using conjugate priors
+
+2.  One-step approach (joint modelling): Fit a Bayesian full multivariate normal repeated measures model using MCMC and then draw a sample.
 
 Here, we illustrate reference-based multiple imputation of a continuous outcome measured repeatedly via the so-called one-step approach.
 
-
 ### Five Macros
-The `five macros` ([Roger 2022](https://baselbiometrics.github.io/home/docs/talks/20221208/5_JamesRoger%2020121118.pdf)), available at [LSHTM DIA Missing Data](https://www.lshtm.ac.uk/research/centres-projects-groups/missing-data#dia-missing-data), fit a Bayesian Normal RM model and then impute post withdrawal data under a series of possible post-withdrawal profiles including J2R, CIR and CR as described by [Carpenter et al. (2013)](https://www.tandfonline.com/doi/full/10.1080/10543406.2013.834911). It then analyses the data using a univariate ANOVA at each visit and summarizes across imputations using Rubin’s rules.  
 
-The following standard and reference-based multiple imputation approaches will be illustrated here: 
-    
-    * MAR (Missing At Random)
-    
-    * CIR (Copy Increment from Reference)
-    
-    * J2R (Jump to Reference)
-    
-    * CR (Copy Reference)
+The `five macros` ([Roger 2022](https://baselbiometrics.github.io/home/docs/talks/20221208/5_JamesRoger%2020121118.pdf)), available at [LSHTM DIA Missing Data](https://www.lshtm.ac.uk/research/centres-projects-groups/missing-data#dia-missing-data), fit a Bayesian Normal RM model and then impute post withdrawal data under a series of possible post-withdrawal profiles including J2R, CIR and CR as described by [Carpenter et al. (2013)](https://www.tandfonline.com/doi/full/10.1080/10543406.2013.834911). It then analyses the data using a univariate ANOVA at each visit and summarizes across imputations using Rubin’s rules.
+
+The following standard and reference-based multiple imputation approaches will be illustrated here:
+
+* MAR (Missing At Random)
+
+* CIR (Copy Increment from Reference)
+
+* J2R (Jump to Reference)
+
+* CR (Copy Reference)
 
 
 ## Data used
+
 A publicly available example [dataset](https://r-packages.io/datasets/antidepressant_data) from an antidepressant clinical trial of an active drug versus placebo is used. Overall, data of 172 patients is available with 88 patients receiving placebo and 84 receiving active drug. The same data is used for the [R part](../R/rbmi_continuous_joint.html).
 
 The relevant endpoint is the Hamilton 17-item depression rating scale (HAMD17) which was assessed at baseline and at weeks 1, 2, 4, and 6 (visits 4-7). Study drug discontinuation occurred in 24% (20/84) of subjects from the active drug and 26% (23/88) of subjects from placebo. All data after study drug discontinuation are missing.
 
-```{r}
+```{sas}
 #| eval: false
 proc print data=dat (obs=10);
-	var PATIENT GENDER THERAPY RELDAYS VISIT BASVAL HAMDTL17 CHANGE;
+	  var PATIENT GENDER THERAPY RELDAYS VISIT BASVAL HAMDTL17 CHANGE;
 run;
 ```
 
@@ -55,12 +57,12 @@ run;
 knitr::include_graphics("../images/rbmi/SAS_ExploreData1.PNG")
 ```
 
-
 The number of patients per visit and arm are:
-```{r}
+
+```{sas}
 #| eval: false
 proc freq data=dat;
-	table VISIT*THERAPY / norow nocol nopercent nocum;
+	  table VISIT*THERAPY / norow nocol nopercent nocum;
 run;
 ```
 
@@ -71,13 +73,13 @@ run;
 knitr::include_graphics("../images/rbmi/SAS_ExploreData2.PNG")
 ```
 
-
 The mean change from baseline of the endpoint (Hamilton 17-item depression rating scale, HAMD17) per visit per treatment group using only the complete cases are:
-```{r}
+
+```{sas}
 #| eval: false
 proc means data=dat n mean nonobs;
-	class VISIT THERAPY;
-	var CHANGE;
+	  class VISIT THERAPY;
+	  var CHANGE;
 run;
 ```
 
@@ -88,18 +90,18 @@ run;
 knitr::include_graphics("../images/rbmi/SAS_ExploreData3.PNG")
 ```
 
-
 The missingness pattern is show below. The incomplete data is primarily monotone in nature. 128 patients have complete data for all visits (all 1’s at each visit). 20, 10 and 13 patients have 1, 2 or 3 monotone missing data, respectively. Further, there is a single additional intermittent missing observation (patient 3618).
-```{r}
+
+```{sas}
 #| eval: false
 proc transpose data=dat out=HAMD_wide(drop=_NAME_) prefix=CHG;
-	by PATIENT THERAPY BASVAL;
-	id VISIT;
-	var CHANGE;
+	  by PATIENT THERAPY BASVAL;
+	  id VISIT;
+	  var CHANGE;
 run;
 
 proc mi data=HAMD_wide nimpute=0 displaypattern=NOMEANS;
-	var CHG4 CHG5 CHG6 CHG7;
+	  var CHG4 CHG5 CHG6 CHG7;
 run;
 ```
 
@@ -110,23 +112,22 @@ run;
 knitr::include_graphics("../images/rbmi/SAS_ExploreData4.PNG")
 ```
 
-
 ## Complete case analysis
-A complete case analysis is performed using mixed model for repeated measures (MMRM) with covariates: treatment [THERAPY], gender [GENDER], visit [VISIT] as factors; baseline score [BASVAL] as continuous; and visit-by-treatment [THERAPY * VISIT] interaction, and visit-by-baseline [BASVAL * VISIT] interaction. An unstructured covariance matrix is used.
-The **MIXED** procedure is used.
 
-```{r}
+A complete case analysis is performed using mixed model for repeated measures (MMRM) with covariates: treatment \[THERAPY\], gender \[GENDER\], visit \[VISIT\] as factors; baseline score \[BASVAL\] as continuous; and visit-by-treatment \[THERAPY \* VISIT\] interaction, and visit-by-baseline \[BASVAL \* VISIT\] interaction. An unstructured covariance matrix is used. The **MIXED** procedure is used.
+
+```{sas}
 #| eval: false
 proc mixed data=dat method=reml;
-	class THERAPY(ref="PLACEBO") VISIT(ref="4") PATIENT GENDER(ref="F");
-	model CHANGE = THERAPY GENDER VISIT BASVAL THERAPY*VISIT BASVAL*VISIT /s ddfm=satterthwaite;
-	repeated VISIT / type=UN subject=PATIENT r;
-	lsmeans THERAPY*VISIT / diff=control("PLACEBO" "7") cl;
+	  class THERAPY(ref="PLACEBO") VISIT(ref="4") PATIENT GENDER(ref="F");
+	  model CHANGE = THERAPY GENDER VISIT BASVAL THERAPY*VISIT BASVAL*VISIT /s ddfm=satterthwaite;
+	  repeated VISIT / type=UN subject=PATIENT r;
+	  lsmeans THERAPY*VISIT / diff=control("PLACEBO" "7") cl;
 run;
 ```
 
-
 The parameter estimates of the fixed effects are:
+
 ```{r}
 #| echo: false
 #| fig-align: center
@@ -134,16 +135,19 @@ The parameter estimates of the fixed effects are:
 knitr::include_graphics("../images/rbmi/SAS_CompleteCase_fixedEstimates.PNG")
 ```
 
-
 The estimated unstructured covariance matrix parameters are:
+
 ```{r}
 #| echo: false
 #| fig-align: center
 #| out-width: 80%
-knitr::include_graphics("../images/rbmi/SAS_CompleteCase_covarianceEstimates.PNG")
+knitr::include_graphics(
+  "../images/rbmi/SAS_CompleteCase_covarianceEstimates.PNG"
+)
 ```
 
-The treatment difference at visit 7 is of interest, and is estimated to be -2.829 (se=1.117) with 95% CI of [-5.033 to -0.624] (p=0.0122).
+The treatment difference at visit 7 is of interest, and is estimated to be -2.829 (se=1.117) with 95% CI of \[-5.033 to -0.624\] (p=0.0122).
+
 ```{r}
 #| echo: false
 #| fig-align: center
@@ -157,20 +161,21 @@ As described above, the so-called `five macros` will be used for the SAS impleme
 
 Applying the `five macros` for reference-based multiple imputation entails the sequential run of the following:
 
-- Part1A declares the parameter estimation model and checks consistency with the dataset. It builds a master dataset which holds details of the current job (run of the macros in sequence). It also builds indexes for the classification variables, which may be either numeric or character.
+-   Part1A declares the parameter estimation model and checks consistency with the dataset. It builds a master dataset which holds details of the current job (run of the macros in sequence). It also builds indexes for the classification variables, which may be either numeric or character.
 
-- Part1B fits the parameter estimation model using the MCMC procedure and draws a pseudo-independent sample from the joint posterior distribution for the linear predictor parameters and the covariance parameters.
+-   Part1B fits the parameter estimation model using the MCMC procedure and draws a pseudo-independent sample from the joint posterior distribution for the linear predictor parameters and the covariance parameters.
 
-- Part2A calculates the predicted mean under MAR, and under MNAR for each subject based on their withdrawal pattern once for each draw of the linear predictor parameter estimates. The choice of MNAR is controlled by the method used, which may vary from subject to subject.
+-   Part2A calculates the predicted mean under MAR, and under MNAR for each subject based on their withdrawal pattern once for each draw of the linear predictor parameter estimates. The choice of MNAR is controlled by the method used, which may vary from subject to subject.
 
-- Part2B imputes the intermediate missing values using MAR and the trailing missing values using MNAR, by deriving the conditional distribution for the missing values conditional on the observed values and covariates, using the appropriate sampled covariance parameter estimates.
+-   Part2B imputes the intermediate missing values using MAR and the trailing missing values using MNAR, by deriving the conditional distribution for the missing values conditional on the observed values and covariates, using the appropriate sampled covariance parameter estimates.
 
-- Part3 carries out a univariate ANOVA analysis at selected time points usually based on the same covariates as the parameter estimation model. It then combines the least-squares means and their differences using the MIANALYZE procedure to provide final results. It is in this macro which handles the Delta methods.
+-   Part3 carries out a univariate ANOVA analysis at selected time points usually based on the same covariates as the parameter estimation model. It then combines the least-squares means and their differences using the MIANALYZE procedure to provide final results. It is in this macro which handles the Delta methods.
 
 Most of the computation time is spent in the Part1B macro where the MCMC procedure is used to generate a sample from the posterior distribution of the full set of model parameters. These are stored away and can be used repeatedly by calling the later macros over and over again using different imputation methods.
 
 To perform reference-based multiple imputation using MAR approach to following code is used
-```{r}
+
+```{sas}
 #| eval: false
 %part1A(jobname = HAMD, 
         Data=dat,
@@ -180,22 +185,27 @@ To perform reference-based multiple imputation using MAR approach to following c
         Treat = THERAPY,
         Covbytime = BASVAL,
         Catcov = GENDER);
+
 %part1B(jobname = HAMD,
         Ndraws = 500,
         thin = 10,
         seed = 12345);
+
 %part2A(jobname = HAMD_MAR,
         inname = HAMD,
         method = MAR);
+
 %part2B(jobname = HAMD_MAR,
         seed = 12345);
+
 %part3(Jobname = HAMD_MAR,
-       anref = PLACEBO,
-       Label = MAR);
+        anref = PLACEBO,
+        Label = MAR);
 ```
 
-To print the results of the contrast at week 7 
-```{r}
+To print the results of the contrast at week 7
+
+```{sas}
 #| eval: false
 proc print data=HAMD_MAR_OUT;
 	where VISIT = "7";
@@ -210,11 +220,11 @@ run;
 knitr::include_graphics("../images/rbmi/SAS_MAR_contrast.PNG")
 ```
 
-
 ## Five macros: MNAR CR approach
 
 To perform reference-based multiple imputation using Copy Reference (CR) approach the following changes are needed in part2A of the 5 macros
-```{r}
+
+```{sas}
 #| eval: false
 %part2A(jobname = HAMD_CR,
         inname = HAMD,
@@ -223,6 +233,7 @@ To perform reference-based multiple imputation using Copy Reference (CR) approac
 ```
 
 The results for M=500 imputations are
+
 ```{r}
 #| echo: false
 #| fig-align: center
@@ -230,11 +241,11 @@ The results for M=500 imputations are
 knitr::include_graphics("../images/rbmi/SAS_MNAR_CR_contrast.PNG")
 ```
 
-
 ## Five macros: MNAR J2R approach
 
 To perform reference-based multiple imputation using Jump to Reference (J2R) approach the following changes are needed in part2A of the 5 macros
-```{r}
+
+```{sas}
 #| eval: false
 %part2A(jobname = HAMD_J2R,
         inname = HAMD,
@@ -243,6 +254,7 @@ To perform reference-based multiple imputation using Jump to Reference (J2R) app
 ```
 
 The results for M=500 imputations are
+
 ```{r}
 #| echo: false
 #| fig-align: center
@@ -250,11 +262,11 @@ The results for M=500 imputations are
 knitr::include_graphics("../images/rbmi/SAS_MNAR_J2R_contrast.PNG")
 ```
 
-
 ## Five macros: MNAR CIR approach
 
 To perform reference-based multiple imputation using Copy Increments in Reference (CIR) approach the following changes are needed in part2A of the 5 macros
-```{r}
+
+```{sas}
 #| eval: false
 %part2A(jobname = HAMD_CIR,
         inname = HAMD,
@@ -263,6 +275,7 @@ To perform reference-based multiple imputation using Copy Increments in Referenc
 ```
 
 The results for M=500 imputations are
+
 ```{r}
 #| echo: false
 #| fig-align: center
@@ -270,40 +283,39 @@ The results for M=500 imputations are
 knitr::include_graphics("../images/rbmi/SAS_MNAR_CIR_contrast.PNG")
 ```
 
-
-
 ## Summary of results
-In the table we present the results of the different imputation strategies (and with varying number, *M*, of multiple imputation draws). Note that some results can be slightly different from the results above due to a possible different seed. The table show the contrast at Visit 7 between DRUG and PLACEBO [DRUG - PLACEBO]:
 
-| Method            | Estimate | SE    | 95% CI           | p-value |
-|-------------------|----------|-------|------------------|---------|
-| Complete Case     | -2.829   | 1.117 | -5.035 to -0.623 | 0.0123  |
-| MI - MAR (M=500)  | -2.810   | 1.122 | -5.029 to -0.592 | 0.0134  |
-| MI - MAR (M=2000) | -2.816   | 1.128 | -5.047 to -0.586 | 0.0137  |
-| MI - MAR (M=5000) | -2.825   | 1.123 | -5.045 to -0.605 | 0.0130  |
-| MI - MNAR CR (M=500)  | -2.384 | 1.120 | -4.598 to -0.170 | 0.0350 |
-| MI - MNAR CR (M=2000) | -2.390 | 1.118 | -4.599 to -0.180 | 0.0342 |
-| MI - MNAR CR (M=5000) | -2.400 | 1.115 | -4.604 to -0.196 | 0.0330 |
-| MI - MNAR J2R (M=500)  | -2.122 | 1.141 | -4.377 to	0.133 | 0.0650 |
-| MI - MNAR J2R (M=2000) | -2.135 | 1.140 | -4.388 to	0.117 | 0.0630 |
-| MI - MNAR J2R (M=5000) | -2.144 | 1.136 | -4.389 to	0.101 | 0.0611 |
-| MI - MNAR CIR (M=500)  | -2.461 | 1.120 | -4.674 to	-0.248 | 0.0296 |
-| MI - MNAR CIR (M=2000) | -2.469 | 1.118 | -4.679 to	-0.260 | 0.0287 |
-| MI - MNAR CIR (M=5000) | -2.481 | 1.115 | -4.684 to	-0.278 | 0.0276 |
+In the table we present the results of the different imputation strategies (and with varying number, *M*, of multiple imputation draws). Note that some results can be slightly different from the results above due to a possible different seed. The table show the contrast at Visit 7 between DRUG and PLACEBO \[DRUG - PLACEBO\]:
 
+| Method                 | Estimate | SE    | 95% CI           | p-value |
+|------------------------|----------|-------|------------------|---------|
+| Complete Case          | -2.829   | 1.117 | -5.035 to -0.623 | 0.0123  |
+| MI - MAR (M=500)       | -2.810   | 1.122 | -5.029 to -0.592 | 0.0134  |
+| MI - MAR (M=2000)      | -2.816   | 1.128 | -5.047 to -0.586 | 0.0137  |
+| MI - MAR (M=5000)      | -2.825   | 1.123 | -5.045 to -0.605 | 0.0130  |
+| MI - MNAR CR (M=500)   | -2.384   | 1.120 | -4.598 to -0.170 | 0.0350  |
+| MI - MNAR CR (M=2000)  | -2.390   | 1.118 | -4.599 to -0.180 | 0.0342  |
+| MI - MNAR CR (M=5000)  | -2.400   | 1.115 | -4.604 to -0.196 | 0.0330  |
+| MI - MNAR J2R (M=500)  | -2.122   | 1.141 | -4.377 to 0.133  | 0.0650  |
+| MI - MNAR J2R (M=2000) | -2.135   | 1.140 | -4.388 to 0.117  | 0.0630  |
+| MI - MNAR J2R (M=5000) | -2.144   | 1.136 | -4.389 to 0.101  | 0.0611  |
+| MI - MNAR CIR (M=500)  | -2.461   | 1.120 | -4.674 to -0.248 | 0.0296  |
+| MI - MNAR CIR (M=2000) | -2.469   | 1.118 | -4.679 to -0.260 | 0.0287  |
+| MI - MNAR CIR (M=5000) | -2.481   | 1.115 | -4.684 to -0.278 | 0.0276  |
 
 ## Discussion
+
 A note on computational time. The total running time (including data loading, setting up data sets, MCMC run, imputing data and analysis MI data) for M=500 was about 23 seconds on a personal laptop. It increased to about 44 seconds for M=2000. Computational time was similar across difference imputation strategies.
 
 With a small number of `Ndraws` in part1B a warning could pop-up "There is still significant autocorrelation after 5 lags, and the effective sample size for the parameter might not be estimated accurately.". Increasing the number of `Ndraws` will mostly solve this warning. For example, for this data example, this message is received when setting `Ndraws` below 100.
 
-
 ## Appendix 1: mmrm as analysis model
+
 Part 3 of the 5 macros carries out a univariate ANOVA analysis at selected time points usually based on the same covariates as the parameter estimation model. It then combines the least-squares means and their differences using Rubin’s formula in a calculation similar to that in the MIANALYZE procedure to provide final results.
 
 Since, all imputed datasets are readily available (after part2B), another possibility is to analyse each imputed dataset using the analysis model of your choice, and combining the results using `PROC MIANALYZE`. For example, suppose an MMRM should be fit on each imputed dataset:
 
-```{r}
+```{sas}
 #| eval: false
 data HAMD_CR_DATAFULL;
 	set HAMD_CR_DATAFULL;
@@ -327,6 +339,7 @@ run;
 ```
 
 The results for M=500 imputations are
+
 ```{r}
 #| echo: false
 #| fig-align: center
@@ -347,4 +360,3 @@ knitr::include_graphics("../images/rbmi/SAS_MNAR_mmrm.PNG")
 [Rubin DB (1976)](https://doi.org/10.1093/biomet/63.3.581). Inference and Missing Data. *Biometrika* 63: 581–592.
 
 [Rubin DB (1987)](https://onlinelibrary.wiley.com/doi/book/10.1002/9780470316696). *Multiple Imputation for Nonresponse in Surveys*. New York: John Wiley & Sons.
-

--- a/SAS/rmst.qmd
+++ b/SAS/rmst.qmd
@@ -1,6 +1,5 @@
 ---
 title: "Restricted Mean Survival Time (RMST) in SAS"
-output: html_document
 date: last-modified
 date-format: D MMMM, YYYY
 ---
@@ -74,11 +73,11 @@ It is good practice to first view the shape of your Kaplan-Meier curves. As you 
 
 It is very important to pre-specify your approach for selection of `tau`. As you can see from the curves, if we compared the period 0 to 6 months, vs 0 to 18 months, we would get very different results for the treatment comparison.
 
-```{r}
+```{sas}
 #| eval: false
-proc lifetest data=adcibc  conftype=log ;
- time time*cnsr(1) ;
- strata trt01pn;
+proc lifetest data=adcibc  conftype=log;
+    time time*cnsr(1);
+    strata trt01pn;
 Run;
 ```
 
@@ -93,30 +92,30 @@ knitr::include_graphics("../images/rmst/kmplot.png")
 
 The code below calculates `tau` as the minimum time of the last event observed in each treatment group. This will be the period of time, our AUC will be calculated over. As cnsr=0 are events, we only select these observations. Below, the maximum event in treatment 1 = 883 days and in treatment 2 = 350 days. We therefore set `tau` = 350. This method avoids including in the AUC a period of time where events are no longer occurring in both treatments. You can see why setting `tau` is very important as we are likely to get very different AUCs calculating over the 350 day as opposed to the 883 day period!
 
-```{r}
+```{sas}
 #| eval: false
 proc sort data=lung_cancer (where=(cnsr=0)) out=tau1;
-  by  trt01pn time;
+    by  trt01pn time;
 run;
 
 data tau1 (keep=studyid trt01pn time);
-  set tau1 ;
-  by trt01pn time;
-  if last.trt01pn then output;
+    set tau1 ;
+    by trt01pn time;
+    if last.trt01pn then output;
 run;
 
 proc sort data=tau1;
-by descending time;
+    by descending time;
 run;
 
 data tau2;
-  set tau1 end=last;
-  by descending time;
-  if last then call symput("_tau",put(time,best8.));
+    set tau1 end=last;
+    by descending time;
+    if last then call symput("_tau",put(time,best8.));
 run;
 
 %put &_tau;
- 350
+350
 ```
 
 ## Method 1: Inverse Probability Censoring Weighting (IPCW) Estimation (proc rmstreg)
@@ -131,14 +130,14 @@ In the output, its important to check that your event/censoring flag is the righ
 
 ### Linear link model - provides estimates of treatment differences
 
-```{r}
+```{sas}
 #| eval: false
 proc rmstreg data=adcibc tau=&_tau;
-class trt01pn sex;
-model time*cnsr(1) =trt01pn sex age /link=linear method=ipcw (strata=trt01pn);
-lsmeans trt01pn/pdiff=control('2') cl alpha=0.05;
-ods output lsmeans=lsm diffs= diff;
-Run;
+    class trt01pn sex;
+    model time*cnsr(1) =trt01pn sex age /link=linear method=ipcw (strata=trt01pn);
+    lsmeans trt01pn/pdiff=control('2') cl alpha=0.05;
+    ods output lsmeans=lsm diffs= diff;
+run;
 ```
 
 ```{r}
@@ -163,15 +162,14 @@ The code is similar to above. We include the option `exp` on the lsmeans row, si
 
 Similar to the linear model, we obtain results of a `restricted mean survival time` estimate of 255.21 days on treatment 1 vs 264.75 days on treatment 2. The difference (Active-Placebo) on the log scale is -0.03667 (95% CI: -0.1493 to 0.07596, p=0.5234) but this is hard to interpret. Hence, once back transformed, the treatment ratio (Active/Placebo) is 0.9640 (95% CI: 0.8613 to 1.0789, p=0.5234).
 
-```{r}
+```{sas}
 #| eval: false
-
 proc rmstreg data=adcibc tau=&_tau;
-class trt01pn sex;
-model time*cnsr(1) =trt01pn sex age /link=log method=ipcw (strata=trt01pn);
-lsmeans trt01pn/pdiff=control('2') cl alpha=0.05 exp;
-ods output lsmeans=lsm diffs= diff;
-Run;
+    class trt01pn sex;
+    model time*cnsr(1) =trt01pn sex age /link=log method=ipcw (strata=trt01pn);
+    lsmeans trt01pn/pdiff=control('2') cl alpha=0.05 exp;
+    ods output lsmeans=lsm diffs= diff;
+run;
 ```
 
 ```{r}
@@ -185,26 +183,26 @@ knitr::include_graphics("../images/rmst/rmstreg_output3.png")
 
 The pseudo-observations method [Andersen, Hansen and Klein 2004](https://pubmed.ncbi.nlm.nih.gov/15690989/), is available in SAS using the method=pv option. You use the link=linear or link=log options and output is similarly interpreted as described for Method 1 IPCW method.
 
-```{r}
+```{sas}
 #| eval: false
 proc rmstreg data=adcibc tau=&_tau;
-class trt01pn sex ;
- model time*cnsr(1) =trt01pn sex age /link=linear  method=pv;
- lsmeans trt01pn/pdiff=control('2') cl alpha=0.05;
- ods output lsmeans=lsm diffs= diff;
-Run;
+    class trt01pn sex ;
+    model time*cnsr(1) =trt01pn sex age /link=linear  method=pv;
+    lsmeans trt01pn/pdiff=control('2') cl alpha=0.05;
+    ods output lsmeans=lsm diffs= diff;
+run;
 ```
 
 ## Method 3: RMST Area under the curve method (proc lifetest)
 
 A non-parametric method to calculate the RMST is available using the AUC Kaplan-Meier curves.
 
-```{r}
+```{sas}
 #| eval: false
 proc lifetest data=adcibc plots=(rmst  s) rmst  (tau=&_tau);
- time time*cnsr(1) ;
- strata trt01pn / diff=control('2') ;
-Run;
+    time time*cnsr(1) ;
+    strata trt01pn / diff=control('2') ;
+run;
 ```
 
 As shown below, SAS only outputs the estimates and SEs. However, a 95% CI (assuming a normal distribution) can be calculated in an additional datastep using estimate +/- 1.96 \* SE.
@@ -236,8 +234,10 @@ knitr::include_graphics("../images/rmst/rmstreg_output4.png")
 
 ```{r}
 #| echo: false
-si <- sessioninfo::session_info("rmst", dependencies = FALSE) 
-si$external <- structure(list("SAS" = "9.04.01M7P08062020"), 
-                         class = c("external_info", "list")) 
+si <- sessioninfo::session_info("rmst", dependencies = FALSE)
+si$external <- structure(
+  list("SAS" = "9.04.01M7P08062020"),
+  class = c("external_info", "list")
+)
 si
 ```

--- a/SAS/rounding.qmd
+++ b/SAS/rounding.qmd
@@ -12,32 +12,31 @@ Both functions allow you to specify the number of decimal places you want to rou
 
 For example (See references for source of the example)
 
-```{markdown}
-# sas code
+```{sas}
+#| eval: false
+data XXX;
+  my_number=2.2;   decimal_paces=1; output;
+  my_number=2.2;   decimal_paces=2;  output;
+  my_number=2.2;;  decimal_paces=3 output;
+  my_number=3.99;  decimal_paces=1;  output;
+  my_number=3.99;  decimal_paces=2; output;
+  my_number=3.99;  decimal_paces=3; output;
+  my_number=1.2345; decimal_paces=1;  output;
+  my_number=1.2345; decimal_paces=2; output;
+  my_number=1.2345; decimal_paces=3; output;
+  my_number=7.876; decimal_paces=1;  output;
+  my_number=7.876; decimal_paces=2; output;
+  my_number=7.876; decimal_paces=3; output;
+  my_number=13.8739; decimal_paces=1;   output;
+  my_number=13.8739; decimal_paces=2;  output;
+  my_number=13.8739; decimal_paces=3;  output;
+run;
 
-    data XXX;
-      my_number=2.2;   decimal_paces=1; output;
-      my_number=2.2;   decimal_paces=2;  output;
-      my_number=2.2;;  decimal_paces=3 output;
-      my_number=3.99;  decimal_paces=1;  output;
-      my_number=3.99;  decimal_paces=2; output;
-      my_number=3.99;  decimal_paces=3; output;
-      my_number=1.2345; decimal_paces=1;  output;
-      my_number=1.2345; decimal_paces=2; output;
-      my_number=1.2345; decimal_paces=3; output;
-      my_number=7.876; decimal_paces=1;  output;
-      my_number=7.876; decimal_paces=2; output;
-      my_number=7.876; decimal_paces=3; output;
-      my_number=13.8739; decimal_paces=1;   output;
-      my_number=13.8739; decimal_paces=2;  output;
-      my_number=13.8739; decimal_paces=3;  output;
-    run;
-
-    data xxx2;
-      set xxx;
-    	round = round(my_number, decimal_places);
-      rounde = rounde(my_number, decimal_places);
-    run;
+data xxx2;
+  set xxx;
+	round = round(my_number, decimal_places);
+  rounde = rounde(my_number, decimal_places);
+run;
 ```
 
 | my_number  | decimal_places | round     | rounde    |
@@ -60,80 +59,76 @@ For example (See references for source of the example)
 
 In some rare cases, `round()` does not return result as expected. For example below.
 
-```{markdown}
-# sas code
-
+```{sas}
+#| eval: false
 data incorrect_round;
-  *rounded=32768.015625, but it should be 32768.015626;
-  rounded=round(32768.0156255,1e-6); output;
-  *rounded=0.137, but it should be 0.138;
-  rounded=round(2048.1375-2048,1e-3); output;
+    *rounded=32768.015625, but it should be 32768.015626;
+    rounded=round(32768.0156255,1e-6); output;
+    *rounded=0.137, but it should be 0.138;
+    rounded=round(2048.1375-2048,1e-3); output;
 run;
 ```
 
 You can find a little more by the code below. It creates dummy numbers with different numbers of decimal digits, and filter incorrect results. Note, the incorrect results are expected when the input number is near or beyond the precision level, i.e. the last decimal of the input number is near or less than the number multiplied by `constant('maceps')`.
 
-```{markdown}
-# sas code
-
+```{sas}
+#| eval: false
 data dum1;
-  int1=0; output;
-  do i=1 to 25;
-    int1=2**i; output;
-  end;
-  keep int1;
+    int1=0; output;
+    do i=1 to 25;
+      int1=2**i; output;
+    end;
+    keep int1;
 run;
 
 data dum2;
-  do round_digits=1 to 7;
-    *x.xxx5 should be rounded up, or replace 5 to 4.99 which should be rounded down;
-    dec1=2**(-round_digits)+10**(-round_digits-1)*5;
-    output;
-  end;
-  keep dec1 round_digits;
+    do round_digits=1 to 7;
+      *x.xxx5 should be rounded up, or replace 5 to 4.99 which should be rounded down;
+      dec1=2**(-round_digits)+10**(-round_digits-1)*5;
+      output;
+    end;
+    keep dec1 round_digits;
 run;
 
 proc sql;
-  create table incorrect_round2(where=(rounded<num1)) as
-  select dum1.*,dum2.*,int1+dec1 as num1,round(calculated num1,10**(-round_digits)) as rounded
-  from dum1, dum2;
+    create table incorrect_round2(where=(rounded<num1)) as
+    select dum1.*,dum2.*,int1+dec1 as num1,round(calculated num1,10**(-round_digits)) as rounded
+    from dum1, dum2;
 quit;
 ```
 
 Or more by the code below and comparing with results from another language, e.g. R.
 
-```{markdown}
-# sas code
-
+```{sas}
+#| eval: false
 data dum1;
-  dec1=0; int1=0; output;
-  do i=0 to 12;
-    dec1=2**(-i);
-    dec1=dec1*1.1;
-    int1=2**i;
-    output;
-  end;
+    dec1=0; int1=0; output;
+    do i=0 to 12;
+      dec1=2**(-i);
+      dec1=dec1*1.1;
+      int1=2**i;
+      output;
+    end;
 run;
 
 proc sql;
-  create table dum3 as select dec1+int1 as num1 from dum1(keep=dec1) a, dum1(keep=int1) b
-  ;
-  create table dat1 as select a.num1,b.num1 as num2 from dum3 a, dum3 b
-;quit;
+    create table dum3 as select dec1+int1 as num1 from dum1(keep=dec1) a, dum1(keep=int1) b;
+    create table dat1 as select a.num1,b.num1 as num2 from dum3 a, dum3 b;
+quit;
 
 data dat2;
-  set dat1;
-  operator='+'; num3=num1+num2; output;
-  operator='-'; num3=num1-num2; output;
-  if num1^=0 and num2^=0 then do;
-    operator='*'; num3=num1*num2; output;
-    operator='/'; num3=num1/num2; output;
-  end;
+    set dat1;
+    operator='+'; num3=num1+num2; output;
+    operator='-'; num3=num1-num2; output;
+    if num1^=0 and num2^=0 then do;
+      operator='*'; num3=num1*num2; output;
+      operator='/'; num3=num1/num2; output;
+    end;
 run;
 
 data dat3;
-  set dat2;
-  rounded=round(num3,1e-3);
+    set dat2;
+    rounded=round(num3,1e-3);
 run;
 ```
 

--- a/SAS/sample_s_StatXact_test_of_trends.qmd
+++ b/SAS/sample_s_StatXact_test_of_trends.qmd
@@ -5,9 +5,7 @@ title: "Sample size for K ordered binomial populations - Cochran-Armitage trend 
 ```{r}
 #| echo: false
 #| include: false
-
 knitr::opts_chunk$set(echo = TRUE)
-
 ```
 
 ### Cochran-Armitage trend test {.unnumbered}
@@ -50,20 +48,20 @@ knitr::include_graphics("../images/samplesize/StatXact3.PNG")
 
 SAS code:
 
-```{r}
+```{sas}
 #| eval: false
 proc sxpowerbin;
-tr/ex;
-palpha 0.025;
-k 5;
-H0 0.001;
-H1 logodds /val=0.5;
-scores 1 2 4 8 16;
-size1 10;
-size2 10;
-size3 10;
-size4 5;
-size5 2;
+    tr/ex;
+    palpha 0.025;
+    k 5;
+    H0 0.001;
+    H1 logodds /val=0.5;
+    scores 1 2 4 8 16;
+    size1 10;
+    size2 10;
+    size3 10;
+    size4 5;
+    size5 2;
 run;
 ```
 
@@ -93,19 +91,19 @@ knitr::include_graphics("../images/samplesize/StatXact5.PNG")
 
 SAS code:
 
-```{r}
+```{sas}
 #| eval: false
 proc sxpowerbin;
-tr/ex dist_file=tr;
-palpha 0.05;
-k 4;
-H0 0.0001;
-H1 logodds /val=0.049;
-scores 0 5 30 75;
-size1 2500;
-size2 3600;
-size3 1450;
-size4 410;
+    tr/ex dist_file=tr;
+    palpha 0.05;
+    k 4;
+    H0 0.0001;
+    H1 logodds /val=0.049;
+    scores 0 5 30 75;
+    size1 2500;
+    size2 3600;
+    size3 1450;
+    size4 410;
 run;
 ```
 
@@ -135,16 +133,16 @@ What is the required sample size to achieve the power of 80% with the significan
 
 SAS code:
 
-```{r}
+```{sas}
 #| eval: false
 proc sxpowerbin ti =15;
-tr/ex;
-palpha 0.05;
-beta 0.8;
-k 5;
-H0 0.10;
-H1 user/val=0.13 0.16 0.19 0.22;
-scores 0 1 2 4 8;
+    tr/ex;
+    palpha 0.05;
+    beta 0.8;
+    k 5;
+    H0 0.10;
+    H1 user/val=0.13 0.16 0.19 0.22;
+    scores 0 1 2 4 8;
 run;
 ```
 

--- a/SAS/sample_s_equivalence.qmd
+++ b/SAS/sample_s_equivalence.qmd
@@ -1,6 +1,5 @@
 ---
 title: "Sample Size for Equivalence Trials in SAS"
-output: html_document
 date: last-modified
 date-format: D MMMM, YYYY
 ---
@@ -29,17 +28,17 @@ For a mean $\mu_1$, we are testing if $\mu_1$ is equivalent to some value $\thet
 
 A reformulation of a treatment pill, needs to have a weight equivalent to a target value of $\theta$ =130 mg. Weight is assumed normally distributed and an acceptable weight is between 110 mg and 150 mg, hence $\delta=20mg$. The standard deviation of the weight is 50 mg. What sample size is needed assuming an alpha level of 5% with 80% power to conclude the weight is within the margin $\delta$ (the tablet weight is equivalent to 130 milligram). The below shows a sample size of 55 pills is required.
 
-```{r}
+```{sas}
 #| eval: false
 PROC POWER  ;
-   onesamplemeans test=equiv   
-   lower  = 110          
-   upper  = 150         
-   mean   = 130     
-   stddev = 50      
-   ntotal = .       
-   power  = 0.8      
-   alpha  = 0.05;    
+    onesamplemeans test=equiv   
+    lower  = 110          
+    upper  = 150         
+    mean   = 130     
+    stddev = 50      
+    ntotal = .       
+    power  = 0.8      
+    alpha  = 0.05;    
 RUN;
 ```
 
@@ -68,17 +67,17 @@ It is anticipated that patients will have the same mean diastolic BP of 96 mmHg 
 
 A total sample size of 90 is recommended, which equates to a sample size of 45 patients per treatment group. Notice how SAS asks for the `lower` and `upper` bounds, these are derived by using the meandiff $\theta$+/- the acceptable equivalence limit $\delta$ (which is stated as 5 mmHg above).
 
-```{r}
+```{sas}
 #| eval: false
 PROC POWER  ;
-   twosamplemeans test=equiv_diff   
-   lower  = -5          
-   upper  = 5   
-   meandiff=0 
-   stddev = 8      
-   ntotal = .       
-   power  = 0.8      
-   alpha  = 0.05;    
+    twosamplemeans test=equiv_diff   
+    lower  = -5          
+    upper  = 5   
+    meandiff=0 
+    stddev = 8      
+    ntotal = .       
+    power  = 0.8      
+    alpha  = 0.05;    
 RUN;
 ```
 
@@ -86,7 +85,9 @@ RUN;
 #| echo: false
 #| fig-align: center
 #| out-width: 50%
-knitr::include_graphics("../images/sample_s_equivalence/SAS2mean_independant.png")
+knitr::include_graphics(
+  "../images/sample_s_equivalence/SAS2mean_independant.png"
+)
 ```
 
 ## **Comparing two independent sample means for parallel design (unpaired samples) where true difference between treatments is believed NOT to be zero and within a tolerance**
@@ -114,17 +115,17 @@ A client is interested in conducting a clinical trial to compare two cholesterol
 
 Below shows a sample size of 140 patients in Total (70 per treatment group).
 
-```{r}
+```{sas}
 #| eval: false
 PROC POWER  ;
-   twosamplemeans test=equiv_diff  
-   lower  = -0.04         
-   upper  = 0.06  
-   meandiff = 0.01 
-   stddev = 0.1     
-   ntotal = .       
-   power  = 0.8      
-   alpha  = 0.05;    
+    twosamplemeans test=equiv_diff  
+    lower  = -0.04         
+    upper  = 0.06  
+    meandiff = 0.01 
+    stddev = 0.1     
+    ntotal = .       
+    power  = 0.8      
+    alpha  = 0.05;    
 RUN;
 ```
 
@@ -153,18 +154,18 @@ Let's consider a standard standard two-sequence, two period crossover design for
 
 The below shows a sample size of 8 patients is required.
 
-```{r}
+```{sas}
 #| eval: false
 PROC POWER;
-   pairedmeans test=equiv_diff   
-   lower  = -35          
-   upper  = 15   
-   meandiff=-10 
-   stddev = 20      
-   npairs = .  
-   corr=0.5
-   power  = 0.8      
-   alpha  = 0.05; 
+    pairedmeans test=equiv_diff   
+    lower  = -35          
+    upper  = 15   
+    meandiff=-10 
+    stddev = 20      
+    npairs = .  
+    corr=0.5
+    power  = 0.8      
+    alpha  = 0.05; 
 RUN;
 ```
 
@@ -185,8 +186,10 @@ knitr::include_graphics("../images/sample_s_equivalence/SAS2crossovermeans.png")
 
 ```{r}
 #| echo: false
-si <- sessioninfo::session_info("sample_s_equivalence", dependencies = FALSE) 
-si$external <- structure(list("SAS" = "9.04.01M7P08062020"), 
-                         class = c("external_info", "list")) 
+si <- sessioninfo::session_info("sample_s_equivalence", dependencies = FALSE)
+si$external <- structure(
+  list("SAS" = "9.04.01M7P08062020"),
+  class = c("external_info", "list")
+)
 si
 ```

--- a/SAS/sample_s_noninferiority.qmd
+++ b/SAS/sample_s_noninferiority.qmd
@@ -1,6 +1,5 @@
 ---
 title: "Sample Size for Non-Inferiority Trials in SAS"
-output: html_document
 date: last-modified
 date-format: D MMMM, YYYY
 ---
@@ -19,19 +18,19 @@ This example is a sample size calculation for the following hypotheses: $H_0:\mu
 
 A client is interested in conducting a clinical trial to compare two cholesterol lowering agents for treatment of hypercholesterolemic patients through a parallel design. The primary efficacy parameter is a low-density lipidprotein cholesterol (LDL-C). We will consider the situation where the intended trial is for testing noninferiority. For establishing it, suppose the true mean difference is 0 and the noninferiority margin is chosen to be -0.05 (-5%). Assuming SD = 0.1, how many patients are required for an 80% power and an overall significance level of 5%?
 
-```{r}
+```{sas}
 #| eval: false
-PROC POWER  ;    
-  twosamplemeans 
-  test=equiv_diff      
-  lower  = 91
-  upper  = 101  
-  meandiff=96 
-  stddev = 8
-  ntotal = .  
-  power  = 0.8
-  alpha  = 0.05;
-  RUN;
+PROC POWER;    
+    twosamplemeans 
+    test=equiv_diff      
+    lower  = 91
+    upper  = 101  
+    meandiff=96 
+    stddev = 8
+    ntotal = .  
+    power  = 0.8
+    alpha  = 0.05;
+RUN;
 ```
 
 As shown below, a total sample size of 102 is recommended, which equates to 51 in each group.
@@ -40,7 +39,9 @@ As shown below, a total sample size of 102 is recommended, which equates to 51 i
 #| echo: false
 #| fig-align: center
 #| out-width: 50%
-knitr::include_graphics("../images/sample_s_noninferiority/2_sample_parallelgroup_means.png")
+knitr::include_graphics(
+  "../images/sample_s_noninferiority/2_sample_parallelgroup_means.png"
+)
 ```
 
 # **Comparing means for crossover design (paired)**
@@ -53,25 +54,27 @@ Let's consider a standard two-sequence, two period crossover design. Suppose tha
 
 Alpha = 0.025 is used below, instead of 0.05 because you are doing non-inferiority (a one sided test). Note that this is still the sample size for alpha=0.05. The below shows a sample size of 13 patients is required.
 
-```{r}
+```{sas}
 #| eval: false
-   pairedmeans 
-   test=equiv_diff
-      lower=-0.3
-      upper=0.1
-      meandiff   = -0.1
-      stddev=0.2
-      corr          = 0.5
-      alpha         = 0.025
-      npairs        = .
-      power         = 0.8;
+pairedmeans 
+test=equiv_diff
+    lower = -0.3
+    upper = 0.1
+    meandiff = -0.1
+    stddev = 0.2
+    corr = 0.5
+    alpha = 0.025
+    npairs = .
+    power = 0.8;
 ```
 
 ```{r}
 #| echo: false
 #| fig-align: center
 #| out-width: 50%
-knitr::include_graphics("../images/sample_s_noninferiority/2_sample_crossover_means.png")
+knitr::include_graphics(
+  "../images/sample_s_noninferiority/2_sample_crossover_means.png"
+)
 ```
 
 ### References
@@ -82,9 +85,12 @@ knitr::include_graphics("../images/sample_s_noninferiority/2_sample_crossover_me
 
 ### Version
 
-{r}
+```{r}
 #| echo: false
-si <- sessioninfo::session_info("sample_s_noninferiority", dependencies = FALSE) 
-si$external <- structure(list("SAS" = "9.04.01M7P08062020"), 
-                         class = c("external_info", "list")) 
+si <- sessioninfo::session_info("sample_s_noninferiority", dependencies = FALSE)
+si$external <- structure(
+  list("SAS" = "9.04.01M7P08062020"),
+  class = c("external_info", "list")
+)
 si
+```

--- a/SAS/sample_s_superiority.qmd
+++ b/SAS/sample_s_superiority.qmd
@@ -37,15 +37,15 @@ A client is interested in conducting a clinical trial to compare two cholesterol
 
 The code below estimates the sample size in SAS. NOTE: you can either specify the MEANDIFF=8 or if you know the separate group means X and Y, you can use GROUPMEANS =X\|Y code instead. SAS also assume a default alpha level of 0.05, a 1:1 balanced randomization and a Normal distribution.
 
-```{r}
+```{sas}
 #| eval: false
 PROC POWER  ;
- TWOSAMPLEMEANS TEST=DIFF
- MEANDIFF=8
- STDDEV=15
- NTOTAL=.
- POWER=0.8
- ;
+    TWOSAMPLEMEANS TEST=DIFF
+    MEANDIFF=8
+    STDDEV=15
+    NTOTAL=.
+    POWER=0.8
+    ;
 RUN;
 ```
 
@@ -68,16 +68,16 @@ Variance of the difference = 2x Variance within patient. Vardiff=2∗Varpatient
 
 We wish to run an AB/BA single dose crossover to compare two brochodilators. The primary outcome is peak expiratory flow, and a clinically relevant difference of 30 l/min is sought with 80% power, the significance level is 5% and the best estimate of the within patient standard deviation is 32 l/min. What size of trial do we require? (After recalculating: 32∗2=45 and assuming no period effect and assuming between each pair of measurements on the same subject that we have a 0.5 correlation)
 
-```{r}
+```{sas}
 #| eval: false
 PROC POWER  ;
- PAIREDMEANS TEST=DIFF
- NPAIRS=.
- corr=0.5
- MEANDIFF=30
- STDDEV=45
- POWER=0.8
- ;
+    PAIREDMEANS TEST=DIFF
+    NPAIRS=.
+    corr=0.5
+    MEANDIFF=30
+    STDDEV=45
+    POWER=0.8
+    ;
 RUN;
 ```
 
@@ -99,8 +99,10 @@ knitr::include_graphics("../images/sample_s_superiority/SAScrossovermeans.png")
 
 ```{r}
 #| echo: false
-si <- sessioninfo::session_info("sample_s_superiority", dependencies = FALSE) 
-si$external <- structure(list("SAS" = "9.04.01M7P08062020"), 
-                         class = c("external_info", "list")) 
+si <- sessioninfo::session_info("sample_s_superiority", dependencies = FALSE)
+si$external <- structure(
+  list("SAS" = "9.04.01M7P08062020"),
+  class = c("external_info", "list")
+)
 si
 ```

--- a/SAS/summary-stats.qmd
+++ b/SAS/summary-stats.qmd
@@ -7,11 +7,11 @@ Percentiles can be calculated in SAS using the UNIVARIATE procedure. The procedu
 This is how the 25th and 40th percentiles of `aval` in the dataset `adlb` could be calculated, using the default option for `PCTLDEF`.
 For quantiles, Q1= 25%, Q2=50%, Q3 = 75%, Q4=100%.
 
-```{r}
+```{sas}
 #| eval: false
 proc univariate data=adlb;
-  var aval;
-  output out=stats pctlpts=25 40 pctlpre=p;
+    var aval;
+    output out=stats pctlpts=25 40 pctlpre=p;
 run;
 ```
 

--- a/SAS/summary_skew_kurt.qmd
+++ b/SAS/summary_skew_kurt.qmd
@@ -11,17 +11,17 @@ knitr::opts_chunk$set(echo = TRUE)
 
 # **Skewness and Kurtosis SAS**
 
-In SAS, Skewness and Kurtosis are usually calculated using `PROC MEANS`. The procedures can produce both statistics in the same call.
-The procedure provides options for different methodologies.
+In SAS, Skewness and Kurtosis are usually calculated using `PROC MEANS`. The procedures can produce both statistics in the same call. The procedure provides options for different methodologies.
 
 ### Data Used
 
 The following data was used in this example.
 
-```         
-  data dat;
-      input team $ points assists;
-      datalines;
+```{sas}
+#| eval: false
+data dat;
+    input team $ points assists;
+    datalines;
   A 10 2
   A 17 5
   A 17 6
@@ -38,19 +38,19 @@ The following data was used in this example.
   C 12 4
   C 11 7
   ;
-  run;
+run;
 ```
 
 ## Procedures Examination {#sas}
 
-By default, SAS `PROC MEANS` uses VARDEF option "DF".  The other options are "N", "WEIGHT", and "WDF. Note that the WEIGHT and WDF options 
-produce no results, as weighted calculations are not supported in PROC MEANS for Skewness and Kurtosis. 
+By default, SAS `PROC MEANS` uses VARDEF option "DF". The other options are "N", "WEIGHT", and "WDF. Note that the WEIGHT and WDF options produce no results, as weighted calculations are not supported in PROC MEANS for Skewness and Kurtosis.
 
 The following shows the SAS documentation for the two measures.
 
 ### Skewness
 
 The [SAS documentation for Skewness](https://documentation.sas.com/doc/en/vdmmlcdc/8.1/casfedsql/p04x27b92gon3gn10e5y5ybxbvmi.htm) is provided here for convenience:
+
 ```{r}
 #| echo: false
 #| fig-align: center
@@ -61,6 +61,7 @@ knitr::include_graphics("../images/summarystats/sas_skewness.png")
 ### Kurtosis
 
 The SAS documentation for Kurtosis is as follows:
+
 ```{r}
 #| echo: false
 #| fig-align: center
@@ -70,12 +71,13 @@ knitr::include_graphics("../images/summarystats/sas_kurtosis.png")
 
 ### VARDEF = DF {#df}
 
-Skewness and Kurtosis are commonly calculated in SAS as follows: 
+Skewness and Kurtosis are commonly calculated in SAS as follows:
 
-```         
-  proc means data=dat SKEWNESS KURTOSIS;
-  var points;
-  run;
+```{sas}
+#| eval: false
+proc means data=dat SKEWNESS KURTOSIS;
+    var points;
+run;
 ```
 
 Output:
@@ -86,16 +88,18 @@ Output:
 #| out-width: 30%
 knitr::include_graphics("../images/summarystats/sas_skewness_kurtosis1.png")
 ```
+
 The above results correspond to the Type 2 methodology in R.
 
 ### VARDEF = N {#n}
 
 The N option produces the following results
 
-```         
-  proc means data=dat SKEWNESS KURTOSIS vardef = N;
-  var points;
-  run;
+```{sas}
+#| eval: false
+proc means data=dat SKEWNESS KURTOSIS vardef = N;
+    var points;
+run;
 ```
 
 Output:
@@ -106,9 +110,9 @@ Output:
 #| out-width: 30%
 knitr::include_graphics("../images/summarystats/sas_skewness_kurtosis2.png")
 ```
+
 The above results correspond to the Type 1 methodology in R.
 
 ## Summary {#summary}
 
-SAS options provide for Type 1 and Type 2 Skewness and Kurtosis.  Skewness Type 3 and 
-Kurtosis Type 3 are not supported. Also Pearson's Kurtosis is not supported.
+SAS options provide for Type 1 and Type 2 Skewness and Kurtosis. Skewness Type 3 and Kurtosis Type 3 are not supported. Also Pearson's Kurtosis is not supported.

--- a/SAS/survey-stats-summary.qmd
+++ b/SAS/survey-stats-summary.qmd
@@ -30,20 +30,22 @@ library(survey)
 data("api")
 
 # View the first few rows of the main dataset
-head(apisrs) |> gt::gt()
+head(apisrs) |>
+  gt::gt()
 ```
 
 ## Mean
 
 If we want to calculate a mean of a variable in a dataset which has been obtained from a **s**imple **r**andom **s**ample such as `apisrs`, in SAS we can do the following (*nb. here `total=6194` is obtained from the constant `fpc` column, and provides the finite population correction*):
 
-``` default
+```{sas}
+#| eval: false
 proc surveymeans data=apisrs total=6194 mean;
     var growth;
 run;
 ```
 
-```         
+``` default
                              The SURVEYMEANS Procedure
 
                                     Data Summary
@@ -64,7 +66,8 @@ run;
 
 To calculate population totals, we can request the `sum`. However SAS requires the user to specify the weights, otherwise the totals will be incorrect. These weights in this case are equivalent to the total population size divided by the sample size:
 
-``` default
+```{sas}
+#| eval: false
 data apisrs;
     set apisrs nobs=n;
     weight = fpc / n;
@@ -76,7 +79,7 @@ proc surveymeans data=apisrs total=6194 sum;
 run;
 ```
 
-```         
+``` default
        The SURVEYMEANS Procedure
 
               Data Summary
@@ -98,13 +101,14 @@ growth            197589           12949
 
 To perform ratio analysis for means or proportions of analysis variables in SAS, we can use the following:
 
-``` default
+```{sas}
+#| eval: false
 proc surveymeans data=apisrs total=6194;
     ratio api00 / api99;
 run;
 ```
 
-```         
+``` default
                              The SURVEYMEANS Procedure
 
                                     Data Summary
@@ -135,13 +139,14 @@ api00     api99                200        1.051066        0.003604    1.04395882
 
 To calculate a proportion in SAS, we use the `PROC SURVEYFREQ`, in the simplest case below:
 
-``` default
+```{sas}
+#| eval: false
 proc surveyfreq data=apisrs total=6194;
-table 'sch.wide'n / cl;
+    table 'sch.wide'n / cl;
 run;
 ```
 
-```         
+``` default
                           The SURVEYFREQ Procedure
 
                                 Data Summary
@@ -164,13 +169,14 @@ run;
 
 To calculate quantiles in SAS, we can use the `quantile` option to request specific quantiles, or can use keywords to request common quantiles (e.g. quartiles or the median). This will use Woodruff's method for confidence intervals, and a custom quantile method [@SAS_2018, pp. 9834].
 
-``` default
+```{sas}
+#| eval: false
 proc surveymeans data=apisrs total=6194 quantile=(0.025 0.5 0.975);
     var growth;
 run;
 ```
 
-```         
+``` default
                              The SURVEYMEANS Procedure
 
                                     Data Summary
@@ -199,12 +205,14 @@ Much of the previous examples and notes still stand for more complex survey desi
 #| echo: false
 data("nhanes")
 
-head(nhanes) |> gt::gt()
+head(nhanes) |>
+  gt::gt()
 ```
 
 To produce means and standard quartiles for this sample, taking account of sample design, we can use the following:
 
-``` default
+```{sas}
+#| eval: false
 proc surveymeans data=nhanes mean quartiles;
     cluster SDMVPSU;
     strata SDMVSTRA;
@@ -213,7 +221,7 @@ proc surveymeans data=nhanes mean quartiles;
 run;
 ```
 
-```         
+``` default
                              The SURVEYMEANS Procedure
 
                                     Data Summary
@@ -246,7 +254,8 @@ run;
 
 To produce an analysis of separate subpopulations in SAS we can use the `DOMAIN` statement (note: do not use the `BY` statement as it will not give statistically valid analysis), here we also request the design effect:
 
-``` default
+```{sas}
+#| eval: false
 proc surveymeans data=nhanes mean deff;
     cluster SDMVPSU;
     strata SDMVSTRA;
@@ -256,8 +265,7 @@ proc surveymeans data=nhanes mean deff;
 run;
 ```
 
-```         
-
+``` default
                The SURVEYMEANS Procedure
 
                       Data Summary
@@ -292,7 +300,11 @@ race    Variable            Mean         of Mean          Effect
 ```{r}
 #| echo: false
 si <- sessioninfo::session_info("survey", dependencies = FALSE)
-si$external <- structure(list("SAS" = "9.04.01M7P080520"), class = c("external_info", "list"))
+si$external <- structure(
+  list("SAS" = "9.04.01M7P080520"),
+  class = c("external_info", "list")
+)
 si
 ```
+
 :::

--- a/SAS/survival.qmd
+++ b/SAS/survival.qmd
@@ -32,7 +32,7 @@ Below is a standard mock-up for survival analysis in clinical trials.
 #| echo: false
 #| fig-align: center
 #| out-width: 75%
-knitr::include_graphics("../images/survival/layout.png")   
+knitr::include_graphics("../images/survival/layout.png")
 ```
 
 ## Example Data
@@ -49,13 +49,13 @@ The data include 500 subjects from the Worcester Heart Attack Study. This study 
 
 -   gender: males = 0, females = 1 - stratification factor
 
-```{r}
+```{sas}
 #| eval: false
 libname mylib "..\data";
 
 data dat;
-set mylib.whas500;
-lenfoly = round(lenfol/365.25, 0.01);  /* change follow-up days to years for better visualization*/
+    set mylib.whas500;
+    lenfoly = round(lenfol/365.25, 0.01);  /* change follow-up days to years for better visualization*/
 run;
 ```
 
@@ -67,11 +67,11 @@ The KM estimators and log-rank test are from `PROC LIFETEST`, and Cox PH model i
 
 ### KM estimators and log-rank test
 
-```{r}
+```{sas}
 #| eval: false
 proc lifetest data=dat outsurv=_SurvEst timelist= 1 3 5 reduceout stderr; 
-time lenfoly*fstat(0);
-strata afb;
+    time lenfoly*fstat(0);
+    strata afb;
 run;
 ```
 
@@ -81,7 +81,7 @@ The landmark estimates and quartile estimates for AFB = 0 group are as shown in 
 #| echo: false
 #| fig-align: center
 #| out-width: 75%
-knitr::include_graphics("../images/survival/sas_km_afib0.png")   
+knitr::include_graphics("../images/survival/sas_km_afib0.png")
 ```
 
 The logrank test result is in below:
@@ -90,16 +90,16 @@ The logrank test result is in below:
 #| echo: false
 #| fig-align: center
 #| out-width: 75%
-knitr::include_graphics("../images/survival/sas_logrank.png")   
+knitr::include_graphics("../images/survival/sas_logrank.png")
 ```
 
 ### Cox PH model
 
-```{r}
+```{sas}
 #| eval: false
 proc phreg data = dat;
-class afb;
-model lenfol*fstat(0) = afb/rl;
+    class afb;
+    model lenfol*fstat(0) = afb/rl;
 run;
 ```
 
@@ -109,25 +109,25 @@ The hazard ratio and confidence intervals are shown as below:
 #| echo: false
 #| fig-align: center
 #| out-width: 75%
-knitr::include_graphics("../images/survival/sas_cox.png")   
+knitr::include_graphics("../images/survival/sas_cox.png")
 ```
 
 ## The Stratified Model
 
 In a stratified model, the Kaplan-Meier estimators remain the same as those in the non-stratified model. To implement stratified log-rank tests and Cox proportional hazards models, simply add the `STRATA` option in both `PROC LIFETEST` and `PROC PHREG`.
 
-```{r}
+```{sas}
 #| eval: false
 # KM estimators and log-rank test
 proc lifetest data=dat;
-time lenfoly*fstat(0);
-strata gender/group = afb;
+    time lenfoly*fstat(0);
+    strata gender/group = afb;
 run;
 
 # Cox PH model
 proc phreg data=dat;
-class afb;
-model lenfol*fstat(0) = afb/rl;
-strata gender;
+    class afb;
+    model lenfol*fstat(0) = afb/rl;
+    strata gender;
 run;
 ```

--- a/SAS/survival_cif.qmd
+++ b/SAS/survival_cif.qmd
@@ -29,30 +29,32 @@ The bone marrow transplant (BTM) dataset as presented by Guo & So (2018) is used
 
 SAS code to prepare the data:
 
-```{r}
+```{sas}
 #| eval: false
 proc format;
-  value DiseaseGroup 1='ALL'
-                     2='AML-Low Risk'
-                     3='AML-High Risk';
-  value EventStatus  0='Censored'
-                     1='Relapse'
-                     2='Death';
+    value DiseaseGroup 1='ALL'
+                      2='AML-Low Risk'
+                      3='AML-High Risk';
+    value EventStatus  0='Censored'
+                      1='Relapse'
+                      2='Death';
 run;
+
 libname datalib "..\data";
 data bmt;
-  set datalib.bmt;
-  TYears = T / 365.25;
-  ID = _n_;
-  format Group DiseaseGroup.;
-  format Status EventStatus.;
+    set datalib.bmt;
+    TYears = T / 365.25;
+    ID = _n_;
+    format Group DiseaseGroup.;
+    format Status EventStatus.;
 run;
 ```
 
 ## Estimating CIFs in SAS
 
 PROC LIFETEST is used to estimate the CIFs in SAS. For illustration, we model the time to relapse.  
-```{r}
+
+```{sas}
 #| eval: false
 ods graphics on;
 proc lifetest data=bmt 
@@ -61,9 +63,9 @@ proc lifetest data=bmt
               conftype=loglog
               outcif=cif1 
               timelist=0.5 1 1.5 2 3; 
-  time Tyears * Status(0) / eventcode=1; 
-  strata Group / order=internal; 
-  format Group DiseaseGroup.;
+    time Tyears * Status(0) / eventcode=1; 
+    strata Group / order=internal; 
+    format Group DiseaseGroup.;
 run; 
 ods graphics off;
 ```

--- a/SAS/survival_csh.qmd
+++ b/SAS/survival_csh.qmd
@@ -35,24 +35,25 @@ The bone marrow transplant (BTM) dataset as presented by Guo & So (2018) is used
 
 -   For illustration, a categorical variable `waitCat` is created from `waitTime` as `waitCat = TRUE` if `waitTime > 200`, and `FALSE` otherwise.
 
-```{r}
+```{sas}
 #| eval: false
 proc format;
-  value DiseaseGroup 1='ALL'
-                     2='AML-Low Risk'
-                     3='AML-High Risk';
-  value EventStatus  0='Censored'
-                     1='Relapse'
-                     2='Death';
+    value DiseaseGroup 1='ALL'
+                      2='AML-Low Risk'
+                      3='AML-High Risk';
+    value EventStatus  0='Censored'
+                      1='Relapse'
+                      2='Death';
 run;
+
 libname datalib "..\data";
 data bmt;
-  set datalib.bmt;
-  TYears = T / 365.25;
-  waitCat = (waitTime>200);
-  ID = _n_;
-  format Group DiseaseGroup.;
-  format Status EventStatus.;
+    set datalib.bmt;
+    TYears = T / 365.25;
+    waitCat = (waitTime>200);
+    ID = _n_;
+    format Group DiseaseGroup.;
+    format Status EventStatus.;
 run;
 ```
 
@@ -62,12 +63,12 @@ run;
 
 Starting in SAS/STAT 14.3, all competing events can be estimated together. However, currently this syntax does not allow the `strata` statement.
 
-```{r}
+```{sas}
 #| eval: false
 proc phreg data=Bmt;
-	title 'Cause-Specific Hazard Regression for Relapse and Death without strata';
-	class Group (order=internal ref=first);
-	model T*Status(0)=Group / eventcode(cox)=1;
+    title 'Cause-Specific Hazard Regression for Relapse and Death without strata';
+    class Group (order=internal ref=first);
+    model T*Status(0)=Group / eventcode(cox)=1;
 run;
 ```
 
@@ -97,14 +98,14 @@ For more information, please see [Guo C and So Y. (2018)](https://support.sas.co
 
 We use `Relapse` as an example.
 
-```{r}
+```{sas}
 #| eval: false
 ods output ParameterEstimates=p1;
 proc phreg data=bmt; 
-  title 'Cause-Specific Hazard Regression for Relapse with strata';
-	class Group (order=internal ref=first) waitCat;
-	strata waitCat;
-	model TYears*Status(0,2) = Group / risklimits alpha = 0.05;
+    title 'Cause-Specific Hazard Regression for Relapse with strata';
+    class Group (order=internal ref=first) waitCat;
+    strata waitCat;
+    model TYears*Status(0,2) = Group / risklimits alpha = 0.05;
 run;
 quit;
 ```

--- a/SAS/tipping_point.qmd
+++ b/SAS/tipping_point.qmd
@@ -43,80 +43,80 @@ The same publicly available [dataset](https://r-packages.io/datasets/antidepress
 
 The relevant endpoint for the antidepressant trial was assessed using the Hamilton 17-item depression rating scale (HAMD17), which was measured at baseline and subsequently at weeks 1, 2, 3, 4 and 6 (visits 4-7). Study drug discontinuation occurred in 24% (20/84) of subjects in the active drug group, compared to 26% (23/88) of subjects in the placebo group. Importantly, all data after study drug discontinuation are missing and there is a single intermittent missing observation.
 
-```{r}
+```{sas}
 #| label: data_exploration_1
 #| eval: false
 proc print data=dat (obs=10);
-  var PATIENT GENDER THERAPY RELDAYS VISIT BASVAL HAMDTL17 CHANGE;
+    var PATIENT GENDER THERAPY RELDAYS VISIT BASVAL HAMDTL17 CHANGE;
 run;
 ```
 
 ```{r}
 #| label: data_exploration_1_png
 #| echo: false
-#| fig-align: 'center'
-#| out-width: '80%'
+#| fig-align: center
+#| out-width: 80%
 knitr::include_graphics("../images/tipping_point/SAS_data_exploration_1.PNG")
 ```
 
 The number of patients per visit and treatment group are:
 
-```{r}
+```{sas}
 #| label: data_exploration_2
 #| eval: false
 proc freq data=dat;
-  table VISIT*THERAPY / norow nocol nopercent nocum;
+    table VISIT*THERAPY / norow nocol nopercent nocum;
 run;
 ```
 
 ```{r}
 #| label: data_exploration_2_png
 #| echo: false
-#| fig-align: 'center'
-#| out-width: '80%'
+#| fig-align: center
+#| out-width: 80%
 knitr::include_graphics("../images/tipping_point/SAS_data_exploration_2.PNG")
 ```
 
 The mean change from baseline of the HAMD17 endpoint per visit and treatment group using only the complete cases are:
 
-```{r}
+```{sas}
 #| label: data_exploration_3
 #| eval: false
 proc means data=dat n mean nonobs;
-  class VISIT THERAPY;
-  var CHANGE;
+    class VISIT THERAPY;
+    var CHANGE;
 run;
 ```
 
 ```{r}
 #| label: data_exploration_3_png
 #| echo: false
-#| fig-align: 'center'
-#| out-width: '80%'
+#| fig-align: center
+#| out-width: 80%
 knitr::include_graphics("../images/tipping_point/SAS_data_exploration_3.PNG")
 ```
 
 The missingness pattern is:
 
-```{r}
+```{sas}
 #| label: data_exploration_4
 #| eval: false
 proc transpose data=dat out=HAMD_wide(drop=_NAME_) prefix=CHG;
-	by PATIENT THERAPY BASVAL;
-	id VISIT;
-	var CHANGE;
+    by PATIENT THERAPY BASVAL;
+    id VISIT;
+    var CHANGE;
 run;
 
 proc mi data=HAMD_wide nimpute=0 displaypattern=NOMEANS;
-	var CHG4 CHG5 CHG6 CHG7;
+    var CHG4 CHG5 CHG6 CHG7;
 run;
 ```
 
 ```{r}
 #| label: data_exploration_4_png
 #| echo: false
-#| fig-align: 'center'
-#| out-width: '80%'
+#| fig-align: center
+#| out-width: 80%
 knitr::include_graphics("../images/tipping_point/SAS_data_exploration_4.PNG")
 ```
 
@@ -142,7 +142,7 @@ As mentioned, we will illustrate the use of the so-called `five macros` in SAS f
 
 To conduct a tipping point analysis under the MAR assumption, we simply specify `method = MAR` under `Part2A()` of the `five macros`. Generally, the rest of `Part1` and `Part2` are the same as in the scenario without any delta adjustment.
 
-```{r}
+```{sas}
 #| label: part_1_2
 #| eval: false
 %part1A(jobname = HAMD, 
@@ -153,13 +153,16 @@ To conduct a tipping point analysis under the MAR assumption, we simply specify 
         Treat = THERAPY,
         Covbytime = BASVAL,
         Catcov = GENDER);
+
 %part1B(jobname = HAMD,
         Ndraws = 500,
         thin = 10,
         seed = 12345);
+
 %part2A(jobname = HAMD_MAR,
         inname = HAMD,
         method = MAR);
+
 %part2B(jobname = HAMD_MAR,
         seed = 12345);
 ```
@@ -174,81 +177,77 @@ A clear description of these arguments is given in the documentation:
 
 To automate the tipping point analysis, you can create a new macro like shown below. The first part of this macro prints all results, while the second part prints the non-significant and significant results separately by filtering on `Probt`.
 
-```{r}
+```{sas}
 #| label: MAR_all_results
 #| eval: false
 data all_results;
-	length DELTA 8 VISIT $10 THERAPY $20 _THERAPY $20 Diff SE_Diff df Probt LCL_Diff UCL_Diff 8;
-	stop;
+    length DELTA 8 VISIT $10 THERAPY $20 _THERAPY $20 Diff SE_Diff df Probt LCL_Diff UCL_Diff 8;
+    stop;
 run;
 
 %macro part3_TP;
 
-  %do delta = -5 %to 10 %by 1;
-  	%part3(Jobname = HAMD_MAR, anref=PLACEBO, Delta = &delta &delta &delta &delta, DLag = 1 0 0 0, DGroups = DRUG, Label=MAR);
-  		
-  	data current_result;
-  		set HAMD_MAR_OUT(keep = VISIT THERAPY _THERAPY Diff SE_Diff df Probt LCL_Diff UCL_Diff);
-  		DELTA = &delta;
-  	run;
-  	
-  	proc append base=all_results data=current_result force nowarn;
-  	run;
-  	
-  %end;
-  	
-  proc print data = all_results noobs label;
-  	where VISIT = "7";
-  	var DELTA VISIT THERAPY _THERAPY Diff SE_Diff df Probt LCL_Diff UCL_Diff;
-  	title "MAR: all results";
-  run;
+%do delta = -5 %to 10 %by 1;
+%part3(Jobname = HAMD_MAR, anref=PLACEBO, Delta = &delta &delta &delta &delta, DLag = 1 0 0 0, DGroups = DRUG, Label=MAR);
 
-  (...)
+data current_result;
+    set HAMD_MAR_OUT(keep = VISIT THERAPY _THERAPY Diff SE_Diff df Probt LCL_Diff UCL_Diff);
+    DELTA = &delta;
+run;
+
+proc append base=all_results data=current_result force nowarn;
+run;
+
+%end;
+proc print data = all_results noobs label;
+    where VISIT = "7";
+    var DELTA VISIT THERAPY _THERAPY Diff SE_Diff df Probt LCL_Diff UCL_Diff;
+    title "MAR: all results";
+run;
 ```
 
 ```{r}
 #| label: MAR_all_results_png
 #| echo: false
-#| fig-align: 'center'
-#| out-width: '80%'
+#| fig-align: center
+#| out-width: 80%
 knitr::include_graphics("../images/tipping_point/SAS_MAR_all_results.png")
 ```
 
-```{r}
+```{sas}
 #| label: MAR_filtered_results
 #| eval: false
-  (...)
-  
-  proc sql noprint;
-	  create table delta_ge_05 as
-		select distinct DELTA
-		from all_results
-		where Probt >= 0.05 and not missing(Probt) and VISIT = "7";
-		
-		select DELTA into :non_sig_delta separated by ' '
-		from delta_ge_05;
-		
-		create table delta_lt_05 as
-		select distinct DELTA
-		from all_results
-		where Probt < 0.05 and not missing(Probt) and VISIT = "7";
-		
-		select DELTA into :sig_delta separated by ' '
-		from delta_lt_05;
-	quit;
-	
-	proc print data = all_results noobs label;
-	  where DELTA in (&non_sig_delta.) and VISIT = "7";
-		var DELTA VISIT THERAPY _THERAPY Diff SE_Diff df Probt LCL_Diff UCL_Diff;
-		title "MAR: non-significant results";
-	run;
 
-	proc print data = all_results noobs label;
-		where DELTA in (&sig_delta.) and VISIT = "7";
-		var DELTA VISIT THERAPY _THERAPY Diff SE_Diff df Probt LCL_Diff UCL_Diff;
-		title "MAR: significant results";
-	run;
-	
+proc sql noprint;
+    create table delta_ge_05 as
+    select distinct DELTA
+    from all_results
+    where Probt >= 0.05 and not missing(Probt) and VISIT = "7";
+
+    select DELTA into :non_sig_delta separated by ' '
+    from delta_ge_05;
+
+    create table delta_lt_05 as
+    select distinct DELTA
+    from all_results
+    where Probt < 0.05 and not missing(Probt) and VISIT = "7";
+
+    select DELTA into :sig_delta separated by ' '
+    from delta_lt_05;
+quit;
+
+proc print data = all_results noobs label;
+    where DELTA in (&non_sig_delta.) and VISIT = "7";
+    var DELTA VISIT THERAPY _THERAPY Diff SE_Diff df Probt LCL_Diff UCL_Diff;
+    title "MAR: non-significant results";
+run;
+
+proc print data = all_results noobs label;
+    where DELTA in (&sig_delta.) and VISIT = "7";
+    var DELTA VISIT THERAPY _THERAPY Diff SE_Diff df Probt LCL_Diff UCL_Diff;
+    title "MAR: significant results";
+run;
+
 %mend;
 
 %part3_TP;
@@ -257,16 +256,16 @@ knitr::include_graphics("../images/tipping_point/SAS_MAR_all_results.png")
 ```{r}
 #| label: MAR_non_sig_results_png
 #| echo: false
-#| fig-align: 'center'
-#| out-width: '80%'
+#| fig-align: center
+#| out-width: 80%
 knitr::include_graphics("../images/tipping_point/SAS_MAR_non_sig_results.png")
 ```
 
 ```{r}
 #| label: MAR_sig_results_png
 #| echo: false
-#| fig-align: 'center'
-#| out-width: '80%'
+#| fig-align: center
+#| out-width: 80%
 knitr::include_graphics("../images/tipping_point/SAS_MAR_sig_results.png")
 ```
 
@@ -275,8 +274,8 @@ To determine the **exact** tipping point between the last "significant" delta an
 ```{r}
 #| label: MAR_TP_png
 #| echo: false
-#| fig-align: 'center'
-#| out-width: '80%'
+#| fig-align: center
+#| out-width: 80%
 knitr::include_graphics("../images/tipping_point/SAS_MAR_TP.png")
 ```
 
@@ -289,8 +288,8 @@ A nice visualization of this tipping point analysis for the MAR approach is:
 ```{r}
 #| label: MAR_est_pval_plot_png
 #| echo: false
-#| fig-align: 'center'
-#| out-width: '80%'
+#| fig-align: center
+#| out-width: 80%
 knitr::include_graphics("../images/tipping_point/SAS_MAR_est_pval.png")
 ```
 
@@ -320,14 +319,14 @@ Of all considered approaches, the MAR approach yields the largest delta adjustme
 ```{r}
 #| label: comparison_est_plot_png
 #| echo: false
-#| fig-align: 'center'
+#| fig-align: center
 knitr::include_graphics("../images/tipping_point/SAS_comparison_est.png")
 ```
 
 ```{r}
 #| label: comparison_pval_plot_png
 #| echo: false
-#| fig-align: 'center'
+#| fig-align: center
 knitr::include_graphics("../images/tipping_point/SAS_comparison_pval.png")
 ```
 
@@ -376,15 +375,15 @@ Let's now consider the antidepressant data again. Suppose we apply a delta adjus
 
 To program this, we would define `Delta`, `DLag` and `DGroups` in `Part3()` of the `five macros` as follows:
 
-```{r}
+```{sas}
 #| eval: false
 #| label: flexible_delta
 %part3(Jobname = HAMD_MAR, 
-       anref=PLACEBO, 
-       Delta = 2 2 2 2, 
-       DLag = 1 1 1 1, 
-       DGroups = DRUG, 
-       Label=MAR);
+        anref=PLACEBO, 
+        Delta = 2 2 2 2, 
+        DLag = 1 1 1 1, 
+        DGroups = DRUG, 
+        Label=MAR);
 ```
 
 Notice that `DLag = 1 1 1 1` is the default for this argument in SAS, you may also leave it unspecified in this case.
@@ -402,14 +401,14 @@ As already illustrated in the tipping point analysis assuming MAR above, you may
 
 To apply this delta = 5 to both groups we leave `DGroups` unspecified.
 
-```{r}
+```{sas}
 #| eval: false
 #| label: fixed_delta
 %part3(Jobname = HAMD_MAR, 
-       anref=PLACEBO, 
-       Delta = 5 5 5 5, 
-       DLag = 1 0 0 0, 
-       Label=MAR);
+        anref=PLACEBO, 
+        Delta = 5 5 5 5, 
+        DLag = 1 0 0 0, 
+        Label=MAR);
 ```
 
 [**Note:**]{.underline} In the `five macros`, delta adjustments are not applied to intermittent missing observations, but only to missing observations after withdrawal. From the documentation, it seems like this cannot be altered. In contrast, the choice of which missing data to apply delta adjustments to can be more freely managed using the `rbmi` R package. This may lead to discrepancies between tipping point analyses conducted in SAS and R, and may have important implications for datasets with high proportions of intermittent missing values in particular.

--- a/SAS/tobit regression SAS.qmd
+++ b/SAS/tobit regression SAS.qmd
@@ -1,5 +1,5 @@
 ---
-title: "<SAS> <Tobit Regression>"
+title: "Tobit Regression"
 ---
 
 # Tobit regression
@@ -30,12 +30,12 @@ The tobit model uses maximum likelihood estimation (for details see for example 
 We assume two equally sized groups (n=10 in each group). The data is censored on the left at a value of $\tau=8.0$.
 In group A 4/10 records are censored, and 1/10 in group B.
 
-```{r}
+```{sas}
 #| label: create data
 #| eval: false
 data dat_used;
-	input ID$ ARM$ Y CENS;
-	cards;
+    input ID$ ARM$ Y CENS;
+    cards;
   001 A 8.0 1 
   002 A 8.0 1
   003 A 8.0 1
@@ -60,48 +60,49 @@ data dat_used;
 run;
 ```
 
-
 ## Example Code using SAS
 
 The analysis will be based on a Tobit analysis of variance with $Y$, rounded to 1 decimal places, as dependent variable and study group as a fixed covariate. A normally distributed error term will be used. Values will be left censored at the value 8.0.
 
 First a data manipulation step needs to be performed in which the censored values are set to missing for a new variable called *lower*.
-```{r}
+
+```{sas}
 #| eval: false
 data dat_used;
-	set dat_used;
-	if Y <= 8.0 then lower=.; else lower=Y;
+    set dat_used;
+    if Y <= 8.0 then lower=.; else lower=Y;
 run;
 ```
-
 
 The data are sorted to make sure the intercept will correspond to the mean of ARM A.
-```{r}
+
+```{sas}
 #| eval: false
 proc sort data=dat_used;
-	by descending ARM;
+    by descending ARM;
 run;
 ```
-
 
 The **LIFEREG** procedure is used for tobit regression. The following model syntax is used:
-<br>
+
+```default
   MODEL (lower,upper)= effects / options ;
-<br>
+```
+
 Here, if the *lower* value is missing, then the *upper* value is used as a left-censored value.
 
-```{r}
+```{sas}
 #| eval: false
 proc lifereg data=dat_used order=data;
-	class ARM;
-	model (lower, Y) = ARM / d=normal;
-	lsmeans ARM /cl alpha=0.05;
-	estimate 'Contrast B-A' ARM 1 -1 / alpha=0.05;
+    class ARM;
+    model (lower, Y) = ARM / d=normal;
+    lsmeans ARM /cl alpha=0.05;
+    estimate 'Contrast B-A' ARM 1 -1 / alpha=0.05;
 run;
 ```
 
-
 The fit statistics, type 3 analysis of effects and parameter estimated are shown here. The output provides an estimate of difference between groups A and B (B-A), namely 1.8225 (se=0.8061). The presented p-value is a two-sided p-value based on the Z-test. The scale parameter is an estimate for $\sigma$.
+
 ```{r}
 #| echo: false
 #| fig-align: center
@@ -110,6 +111,7 @@ knitr::include_graphics("../images/tobit/SAS_tobit_1.PNG")
 ```
 
 The p-value and confidence intervals of the contrast B-A are shown here. The p-value is the same as above.
+
 ```{r}
 #| echo: false
 #| fig-align: center
@@ -117,11 +119,8 @@ The p-value and confidence intervals of the contrast B-A are shown here. The p-v
 knitr::include_graphics("../images/tobit/SAS_tobit_2.PNG")
 ```
 
-
 ## Reference
 
 Breen, R. (1996). Regression models. SAGE Publications, Inc., https://doi.org/10.4135/9781412985611
 
 Tobin, James (1958). "Estimation of Relationships for Limited Dependent Variables". Econometrica. 26 (1): 24-36. doi:10.2307/1907382
-
-

--- a/SAS/ttest_1Sample.qmd
+++ b/SAS/ttest_1Sample.qmd
@@ -15,10 +15,11 @@ In SAS, a one sample t-test is usually performed using PROC TTEST. The one sampl
 
 The following data was used in this example.
 
-```         
-  data read;
-     input score count @@;
-     datalines;
+```{sas}
+#| eval: false
+data read;
+  input score count @@;
+  datalines;
   40 2   47 2   52 2   26 1   19 2
   25 2   35 4   39 1   26 1   48 1
   14 2   22 1   42 1   34 2   33 2
@@ -36,10 +37,11 @@ By default, SAS PROC TTEST t-test assumes normality in the data and uses a class
 
 The following code was used to test the comparison of a reading scores against a baseline hypothesis value of 30:
 
-```         
-  proc ttest data=read h0=30;
-     var score;
-  run;
+```{sas}
+#| eval: false
+proc ttest data=read h0=30;
+    var score;
+run;
 ```
 
 Output:
@@ -59,10 +61,11 @@ The SAS one sample t-test also supports lognormal analysis for a one sample t-te
 
 Using the same data as above, we will set the "DIST" option to "lognormal" to perform this analysis:
 
-```         
-  proc ttest data=read h0=30 dist=lognormal;
-     var score;
-  run;
+```{sas}
+#| eval: false
+proc ttest data=read h0=30 dist=lognormal;
+    var score;
+run;
 ```
 
 Output:

--- a/SAS/ttest_2Sample.qmd
+++ b/SAS/ttest_2Sample.qmd
@@ -13,11 +13,12 @@ knitr::opts_chunk$set(echo = TRUE)
 
 The following data was used in this example.
 
-```         
+```{sas}
+#| eval: false
 data d1;
-  length trt_grp $ 9;
-  input trt_grp $ WtGain @@;
-  datalines;
+    length trt_grp $ 9;
+    input trt_grp $ WtGain @@;
+    datalines;
 placebo    94 placebo    12 placebo    26 placebo    89 
 placebo    88 placebo    96 placebo    85 placebo   130 
 placebo    75 placebo    54 placebo   112 placebo    69 
@@ -38,17 +39,17 @@ In SAS the following code was used to test the mean comparison (mean of Weight G
 
 For this example, we're testing the significant difference in mean of Weight gain (*WtGain*) between treatment and placebo (*trt_grp*) using PROC TTEST procedure in SAS.
 
-```{r}
+```{sas}
 #| eval: false 
-  proc ttest data=d1; 
-     class trt_grp; 
-     var WtGain; 
-  run; 
+proc ttest data=d1; 
+    class trt_grp; 
+    var WtGain; 
+run; 
 ```
 
 Output:
 
-```         
+```default
              Figure 1: Test results for independent t-test using PROC TTEST in SAS
 ```
 
@@ -67,17 +68,17 @@ Note: Before entering straight into the t-test we need to check whether the assu
 
 1.  Normality: You can check for data to be normally distributed by plotting a histogram of the data by treatment. Alternatively, you can use the Shapiro-Wilk test or the Kolmogorov-Smirnov test. If the test is \<0.05 and your sample is quite small then this suggests you should not use the t-test. However, if your sample in each treatment group is large (say \>30 in each group), then you do not need to rely so heavily on the assumption that the data have an underlying normal distribution in order to apply the two-sample t-test. This is where plotting the data using histograms can help to support investigation into the normality assumption. We have checked the normality of the observations using the code below. Here for both the treatment groups we have P value greater than 0.05 (Shapiro-Wilk test is used), therefore the normality assumption is there for our data.
 
-```{r}
+```{sas}
 #| eval: false 
-    proc univariate data=d1 normal;  
-      qqplot WtGain; 
-      by trt_grp; 
-    run; 
+proc univariate data=d1 normal;  
+    qqplot WtGain; 
+    by trt_grp; 
+run; 
 ```
 
 Output:
 
-```         
+```default
         Figure 2: The results of normality test for Treatment group
 ```
 
@@ -88,7 +89,7 @@ Output:
 knitr::include_graphics("../images/ttest/trt_sas.png")
 ```
 
-```         
+```default
        Figure 3: The results of normality test for Placebo group
 ```
 
@@ -103,7 +104,7 @@ knitr::include_graphics("../images/ttest/placb_sas.png")
 
 Output:
 
-```         
+```default
                     Figure 4: Folded F-test result in PROC TTEST
 ```
 

--- a/SAS/ttest_Paired.qmd
+++ b/SAS/ttest_Paired.qmd
@@ -1,6 +1,5 @@
 ---
 title: "Paired t-test"
-output: html_document
 ---
 
 ```{r}
@@ -23,10 +22,11 @@ By default, SAS PROC TTEST t-test assumes normality in the data and uses a class
 
 The following data was used in this example.
 
-```         
-  data pressure;
-     input SBPbefore SBPafter @@;
-     datalines;
+```{sas}
+#| eval: false
+data pressure;
+    input SBPbefore SBPafter @@;
+    datalines;
   120 128   124 131   130 131   118 127
   140 132   128 125   140 141   135 137
   126 118   130 132   126 129   127 135
@@ -37,10 +37,11 @@ The following data was used in this example.
 
 The following code was used to test the comparison of two paired samples of Systolic Blood Pressure before and after a procedure.
 
-```         
-  proc ttest data=pressure;
-     paired SBPbefore*SBPafter;
-  run;
+```{sas}
+#| eval: false
+proc ttest data=pressure;
+    paired SBPbefore*SBPafter;
+run;
 ```
 
 Output:
@@ -58,10 +59,11 @@ The SAS paired t-test also supports analysis of lognormal data. Here is the data
 
 ### Data
 
-```         
-  data auc;
-     input TestAUC RefAUC @@;
-     datalines;
+```{sas}
+#| eval: false
+data auc;
+    input TestAUC RefAUC @@;
+    datalines;
   103.4 90.11  59.92 77.71  68.17 77.71  94.54 97.51
   69.48 58.21  72.17 101.3  74.37 79.84  84.44 96.06
   96.74 89.30  94.26 97.22  48.52 61.62  95.68 85.80
@@ -72,10 +74,11 @@ The SAS paired t-test also supports analysis of lognormal data. Here is the data
 
 For cases when the data is lognormal, SAS offers the "DIST" option to chose between a normal and lognormal distribution. The procedure also offers the TOST option to specify the equivalence bounds.
 
-```         
-  proc ttest data=auc dist=lognormal tost(0.8, 1.25);
-     paired TestAUC*RefAUC;
-  run;
+```{sas}
+#| eval: false
+proc ttest data=auc dist=lognormal tost(0.8, 1.25);
+    paired TestAUC*RefAUC;
+run;
 ```
 
 Output:

--- a/SAS/wilcoxonsr_HL.qmd
+++ b/SAS/wilcoxonsr_HL.qmd
@@ -18,11 +18,11 @@ Again, wilcoxon signed rank test was applied to analyse the time to return to ba
 
 Let's consider a case where the dataset has no ties and N (number of observations) = 240.
 
-```{r}
+```{sas}
 #| eval: false
 data TTR;
-  set TTR;
-  diff = TRT_B - TRT_A;
+    set TTR;
+    diff = TRT_B - TRT_A;
 run;
 ```
 
@@ -35,11 +35,11 @@ knitr::include_graphics("../images/wilcoxonsr/wsr_data.PNG")
 
 In SAS Wilcoxon Signed-Rank test is available using PROC UNIVARIATE.
 
-```{r}
+```{sas}
 #| eval: false
 proc univariate data=TTR
-	alpha=0.1;
-	var diff;
+    alpha=0.1;
+    var diff;
 run;
 ```
 
@@ -54,7 +54,7 @@ knitr::include_graphics("../images/wilcoxonsr/wsr_240.PNG")
 
 Now let's consider a smaller dataset, created by selecting first 19 observations from our main data.
 
-```{r}
+```{sas}
 #| eval: false
 data TTR_19;
     set TTR;
@@ -62,14 +62,13 @@ data TTR_19;
 run;
 ```
 
-```{r}
+```{sas}
 #| eval: false
 proc univariate data=TTR_19
-	alpha=0.1;
-	var diff;
+    alpha=0.1;
+    var diff;
 run;
 ```
-
 
 ```{r}
 #| echo: false
@@ -94,19 +93,17 @@ knitr::include_graphics("../images/wilcoxonsr/wsr_19.PNG")
 
 ## Analysis in StatXact® {.unnumbered}
 StatXact® PROCs for SAS users is a clinical trial analysis software from Cytel for exact statistics. Package includes more than 150 procedures for exact inference statistical data and power analysis.
- 
- 
+
 ### Dataset without ties and N > 20 {.unnumbered}
-```{r}
+```{sas}
 #| eval: false
 /* Wilxocon S-R test - p values */
 PROC PAIRED DATA=WilcoxonSignedRank_TTR
-ALPHA=0.9;
-WI/EX;
-POPS TRT_B - TRT_A;
+    ALPHA=0.9;
+    WI/EX;
+    POPS TRT_B - TRT_A;
 RUN;
 ```
-
 
 ```{r}
 #| echo: false
@@ -115,16 +112,15 @@ RUN;
 knitr::include_graphics("../images/wilcoxonsr/wsrSX_240a.PNG")
 ```
 
-```{r}
+```{sas}
 #| eval: false
 /* Wilcoxon S-R - H-L estimator and CI */
 PROC PAIRED DATA=WilcoxonSignedRank_TTR 
-ALPHA=0.9;
-HL/EX;
-POPS TRT_B - TRT_A;
+    ALPHA=0.9;
+    HL/EX;
+    POPS TRT_B - TRT_A;
 RUN;
 ```
-
 
 ```{r}
 #| echo: false
@@ -138,7 +134,6 @@ knitr::include_graphics("../images/wilcoxonsr/wsrSX_240b.PNG")
 -   Follows Sprent (1993) approach for Wilcoxon Signed-Rank test and Lehmann (1975) for H-L estimate and CI
 -   Provides exact/non-exact p values, (exact) H-L estimator and exact/non-exact CIs
 -   p value is based on a common T+ statistic (sum of ranks of the positive differences)
-
 
 ### Approach to 0s and ties in StatXact® {.unnumbered}
 -   Using ZEROS option we can compute H-L estimate including all differences, but by default 0s are excluded.


### PR DESCRIPTION
### Main Changes
Similar to #466, all files in the `SAS/` folder were evaluated for consistency. 
1. All SAS code was enclosed in `{sas}` code blocks with `|# eval: false` yaml options specified. Again, I don't think this is any better or worse than existing options, but atleast in all files it is consistent now. 
2. I attempted some code spacing formatting with SAS code just for readability.
3. Any SAS output code blocks I defined as 'default'. The `SAS/logist-reg.qmd` file had a lot of those, but I think breaking it all apart will be helpful for a reader. Might be helpful to look at that file and other places just to make sure I didn't impact any outputs or results in a meaningful way.
4. Other small white space changes, but I think most are ok and likely a result of me editing them in Source mode as it was easier to see all the code and adjust many of the code chunks.

### Things I did not touch or add
1. Again, I think it would be great to be able to use consistent datasets.
2. I did not attempt to standardize 'capitalization' or CAPITALIZATION'. I know it doesn't matter, but it would be nice to have a standard choice in this repository and go with it just so it is not distracting for new people.

Something I came across in a couple files were many macros. I don't know enough about them, but is it worth having a section on how to "get" them? They seem critical to some of the functions and code. Or atleast maybe having a link to the SAS document on them? 

This should close #445.