### PR TITLE
removed second image in header

### DIFF
--- a/blogs/posts/2025-11-25_ref-based-multiple-imputation/index.qmd
+++ b/blogs/posts/2025-11-25_ref-based-multiple-imputation/index.qmd
@@ -6,7 +6,7 @@ categories:
   - R
   - SAS
 date: 2025-11-25
-image: rbmi1.jpg rbmi2.jpg
+image: rbmi1.jpg
 ---
 
 A recent PHUSE CAMIS contribution (in collaboration with PSI AIMS SIG) explored the implementation of reference-based multiple imputation in R and SAS, and a comparison of both. The focus was on continuous longitudinal endpoints.


### PR DESCRIPTION
removed second image rbmi2.jpg from header as looks like this is causing no image to display in CAMIS Blog home page