### PR TITLE
Fix renv restore in CI by pinning a dated PPM snapshot; add survRM2

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -6,7 +6,10 @@ name: Render and Publish
 
 jobs:
   build-deploy:
-    runs-on: ubuntu-latest
+    # Pinned deliberately: setup-renv keys its package cache on the OS string,
+    # so a floating ubuntu-latest silently invalidates every cache when GitHub
+    # migrates the image (this is what broke CI in July 2026).
+    runs-on: ubuntu-24.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes

--- a/.github/workflows/pull_request_action.yml
+++ b/.github/workflows/pull_request_action.yml
@@ -11,7 +11,10 @@ name: Test Rendering
 
 jobs:
   build-deploy:
-    runs-on: ubuntu-latest
+    # Pinned deliberately: setup-renv keys its package cache on the OS string,
+    # so a floating ubuntu-latest silently invalidates every cache when GitHub
+    # migrates the image (this is what broke CI in July 2026).
+    runs-on: ubuntu-24.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes

--- a/contribution/get_started.qmd
+++ b/contribution/get_started.qmd
@@ -106,6 +106,32 @@ renv::restore()
 
 These function calls help to record and update the `renv.lock` file with the package and associated dependencies in a reproducible manner.
 
+::: {.callout-warning}
+## Check your `renv::snapshot()` diff before committing
+
+`renv::snapshot()` records your *local* environment, not just the package you added, so it can quietly sweep unrelated changes into the lockfile. Before committing, run `git diff renv.lock requirements.txt` and confirm the only changes are the ones you meant to make. Two in particular catch people out:
+
+-   **`requirements.txt` and the `Python` block of `renv.lock`.** `renv` rewrites both from whichever Python environment is active. If that is not the project's Python 3.12 virtualenv, `requirements.txt` is replaced by whatever your interpreter happens to have installed — on one occasion this cut it from 124 packages down to one. Unless you deliberately intended to change the Python environment, undo those with `git checkout -- requirements.txt` and restore the original `Python` block.
+-   **The recorded R version.** CI installs the R version named in `renv.lock`, and a snapshot sets it to whatever R *you* are running.
+
+Commit only the R package records unless a wider change is the point of your pull request.
+:::
+
+::: {.callout-note}
+## The package repository is pinned to a fixed date
+
+`renv.lock` points at a dated [Posit Package Manager](https://packagemanager.posit.co) snapshot rather than `latest`. This is deliberate: it means every recorded version still has a prebuilt binary available on Linux, macOS and Windows, so nobody needs a working compiler toolchain to run `renv::restore()`. Pointing at `latest` breaks this, because `latest` only ever serves the *current* version of each package, and anything pinned to an older version then has to be built from source.
+
+Two consequences when adding a package:
+
+-   `renv::install("package_name")` installs the version that was current on the snapshot date, not today's version.
+-   A package published to CRAN *after* the snapshot date cannot be installed until the date is moved forward.
+
+Moving the date means re-snapshotting the whole lockfile, which shifts many package versions at once and invalidates most of the Quarto freeze cache. Please raise that as its own pull request rather than folding it into a content change.
+
+Packages that ship with R itself — `mgcv`, `Matrix`, `survival`, `lattice` and friends — are deliberately left out of the lockfile via `ignored.packages` in `renv/settings.json`. Their versions follow your R installation rather than CRAN, so they can never be pinned reliably, and recording them causes `renv::restore()` to fail.
+:::
+
 At this point, it is assumed that your system in RStudio is connected to Git and GitHub, and that the `renv` environment is successfully activated. Now every time you close RStudio and reopen the CAMIS project on your computer, you should see the option:
 
 ```{r}

--- a/renv.lock
+++ b/renv.lock
@@ -1,10 +1,10 @@
 {
   "R": {
-    "Version": "4.5.2",
+    "Version": "4.5.3",
     "Repositories": [
       {
         "Name": "CRAN",
-        "URL": "https://packagemanager.posit.co/cran/latest"
+        "URL": "https://packagemanager.posit.co/cran/2026-08-14"
       }
     ]
   },
@@ -14,6 +14,13 @@
     "Name": "./renv/python/virtualenvs/renv-python-3.12"
   },
   "Packages": {
+    "AsioHeaders": {
+      "Package": "AsioHeaders",
+      "Version": "1.30.2-1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "a6d3ad7ba83bd5dc4b9c13b685b2b4a4"
+    },
     "BH": {
       "Package": "BH",
       "Version": "1.90.0-1",
@@ -37,14 +44,27 @@
     },
     "DBI": {
       "Package": "DBI",
-      "Version": "1.2.3",
+      "Version": "1.3.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "methods"
       ],
-      "Hash": "065ae649b05f1ff66bb0c793107508f5"
+      "Hash": "dbfa2adb83f8063640982459e153f650"
+    },
+    "DFBA": {
+      "Package": "DFBA",
+      "Version": "0.1.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "graphics",
+        "methods",
+        "stats"
+      ],
+      "Hash": "8dda5e864eeb9fe227bcac7db8a0d7df"
     },
     "DOS2": {
       "Package": "DOS2",
@@ -81,13 +101,14 @@
     },
     "Deriv": {
       "Package": "Deriv",
-      "Version": "4.2.0",
+      "Version": "4.3.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
+        "Rcpp",
         "methods"
       ],
-      "Hash": "3c3130705944f882654c991829c0b5bc"
+      "Hash": "70e217897316149c9c655ad78b379fa1"
     },
     "DescTools": {
       "Package": "DescTools",
@@ -137,7 +158,7 @@
     },
     "FactoMineR": {
       "Package": "FactoMineR",
-      "Version": "2.13",
+      "Version": "2.16",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -151,27 +172,32 @@
         "flashClust",
         "ggplot2",
         "ggrepel",
+        "ggtext",
         "grDevices",
         "graphics",
+        "irlba",
         "lattice",
         "leaps",
         "multcompView",
+        "scales",
         "scatterplot3d",
+        "showtext",
         "stats",
+        "sysfonts",
         "utils"
       ],
-      "Hash": "7712f6d5b2d91bf4ead51ba97d7a5c9a"
+      "Hash": "2f9baeca11e74364b6dc171f76a17aa6"
     },
     "Formula": {
       "Package": "Formula",
-      "Version": "1.2-5",
+      "Version": "1.2-6",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "stats"
       ],
-      "Hash": "7a29697b75e027767a53fde6c903eca7"
+      "Hash": "a2fceb52bfbc3be9df984e98755f9ae1"
     },
     "GLMMadaptive": {
       "Package": "GLMMadaptive",
@@ -199,7 +225,7 @@
     },
     "Hmisc": {
       "Package": "Hmisc",
-      "Version": "5.2-5",
+      "Version": "5.2-6",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -223,40 +249,7 @@
         "rpart",
         "viridisLite"
       ],
-      "Hash": "883b941aee155e7d7d6cdf35b17080d1"
-    },
-    "KMsurv": {
-      "Package": "KMsurv",
-      "Version": "0.1-6",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "9b4949ea5c24451e7b3c7e1c1647801b"
-    },
-    "KernSmooth": {
-      "Package": "KernSmooth",
-      "Version": "2.23-26",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "stats"
-      ],
-      "Hash": "2fb39782c07b5ad422b0448ae83f64c4"
-    },
-    "MASS": {
-      "Package": "MASS",
-      "Version": "7.3-65",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "grDevices",
-        "graphics",
-        "methods",
-        "stats",
-        "utils"
-      ],
-      "Hash": "a41d0fc833ea756a1136b60a437efe26"
+      "Hash": "30eba6d0597b6af63edeb31056fdbab1"
     },
     "MatchIt": {
       "Package": "MatchIt",
@@ -276,23 +269,6 @@
         "utils"
       ],
       "Hash": "4605e6e151faa5275ee1eaae441c5f24"
-    },
-    "Matrix": {
-      "Package": "Matrix",
-      "Version": "1.7-4",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "grDevices",
-        "graphics",
-        "grid",
-        "lattice",
-        "methods",
-        "stats",
-        "utils"
-      ],
-      "Hash": "7dbe8933065523bfc227027091bf2b1f"
     },
     "MatrixModels": {
       "Package": "MatrixModels",
@@ -331,10 +307,10 @@
     },
     "QuickJSR": {
       "Package": "QuickJSR",
-      "Version": "1.9.0",
+      "Version": "1.10.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "3026f0119ebb60c5c12028f857f83291"
+      "Hash": "08b7b1ee36f1ad560fe72b1588a6f5d2"
     },
     "R6": {
       "Package": "R6",
@@ -358,7 +334,7 @@
     },
     "Rcpp": {
       "Package": "Rcpp",
-      "Version": "1.1.1",
+      "Version": "1.1.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -366,11 +342,11 @@
         "methods",
         "utils"
       ],
-      "Hash": "60df6f11cbeffbf9d50ad0852867f6b6"
+      "Hash": "f481f89daa906a34eab8ef8658c8a89c"
     },
     "RcppArmadillo": {
       "Package": "RcppArmadillo",
-      "Version": "15.2.3-1",
+      "Version": "15.4.2-1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -380,7 +356,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "180d6ae1fc15b124e1ea2ea95555d385"
+      "Hash": "f7694f9bd161314b273073279998a69b"
     },
     "RcppEigen": {
       "Package": "RcppEigen",
@@ -397,13 +373,13 @@
     },
     "RcppParallel": {
       "Package": "RcppParallel",
-      "Version": "5.1.11-1",
+      "Version": "6.2.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "07d228a359f31d8aebe6d2f643c1f012"
+      "Hash": "ae97343f2392836689f02881879ff787"
     },
     "RcppProgress": {
       "Package": "RcppProgress",
@@ -439,14 +415,14 @@
     },
     "S7": {
       "Package": "S7",
-      "Version": "0.2.1",
+      "Version": "0.2.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "9da85950949574264f92f91f0e23de26"
+      "Hash": "6a72e94a8c9be4ef719af3aa3628f2dc"
     },
     "SampleSize4ClinicalTrials": {
       "Package": "SampleSize4ClinicalTrials",
@@ -495,7 +471,7 @@
     },
     "TMB": {
       "Package": "TMB",
-      "Version": "1.9.19",
+      "Version": "1.9.23",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -507,7 +483,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "17093525d3c647976a5da3538f9f12d7"
+      "Hash": "298f827b699d7d905260516b1c7b3544"
     },
     "TrialSize": {
       "Package": "TrialSize",
@@ -518,7 +494,7 @@
     },
     "V8": {
       "Package": "V8",
-      "Version": "8.0.1",
+      "Version": "8.2.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -527,7 +503,7 @@
         "jsonlite",
         "utils"
       ],
-      "Hash": "f0301ca7b867eeb5c9b586a9e400729a"
+      "Hash": "9fcf4128ded76196cf5f9e731d5e14ef"
     },
     "VGAM": {
       "Package": "VGAM",
@@ -593,13 +569,13 @@
     },
     "backports": {
       "Package": "backports",
-      "Version": "1.5.0",
+      "Version": "1.5.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "e1e1b9d75c37401117b636b7ae50827a"
+      "Hash": "e3e65442a2749b59692220f368f46c46"
     },
     "base64enc": {
       "Package": "base64enc",
@@ -613,7 +589,7 @@
     },
     "bayestestR": {
       "Package": "bayestestR",
-      "Version": "0.17.0",
+      "Version": "0.18.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -625,7 +601,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "06396210f1414b47a2702eb5d574934c"
+      "Hash": "ca4a1cadca567b46156e073e6deab1dc"
     },
     "bdsmatrix": {
       "Package": "bdsmatrix",
@@ -674,7 +650,7 @@
     },
     "bit64": {
       "Package": "bit64",
-      "Version": "4.6.0-1",
+      "Version": "4.8.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -685,14 +661,14 @@
         "stats",
         "utils"
       ],
-      "Hash": "4f572fbc586294afff277db583b9060f"
+      "Hash": "71778c0b60bbf439ac64e6a8be695917"
     },
     "bitops": {
       "Package": "bitops",
-      "Version": "1.0-9",
+      "Version": "1.1-0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "d972ef991d58c19e6efa71b21f5e144b"
+      "Hash": "baf391dcfdfee22a934bdc688a4c0adf"
     },
     "blob": {
       "Package": "blob",
@@ -706,21 +682,9 @@
       ],
       "Hash": "1e0ae40898be928695fd90a80e816253"
     },
-    "boot": {
-      "Package": "boot",
-      "Version": "1.3-32",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "graphics",
-        "stats"
-      ],
-      "Hash": "d39b147eb7fe9df64a1a55f72346360c"
-    },
     "bpcp": {
       "Package": "bpcp",
-      "Version": "1.4.2",
+      "Version": "1.5.5",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -729,7 +693,7 @@
         "stats",
         "survival"
       ],
-      "Hash": "31fa7c29be33fb72d3338e0cabf31174"
+      "Hash": "4ca2b7f6ebfd6f7e86210415574644c7"
     },
     "brio": {
       "Package": "brio",
@@ -743,7 +707,7 @@
     },
     "broom": {
       "Package": "broom",
-      "Version": "1.0.12",
+      "Version": "1.0.13",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -760,11 +724,11 @@
         "tibble",
         "tidyr"
       ],
-      "Hash": "6cf2f6757591ea712c57c5d7bedc3c27"
+      "Hash": "b91eb25282a25d746f84dbd340ace9db"
     },
     "bslib": {
       "Package": "bslib",
-      "Version": "0.10.0",
+      "Version": "0.12.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -782,7 +746,7 @@
         "rlang",
         "sass"
       ],
-      "Hash": "d6072fb96c4868d8cb40d4071cdc472b"
+      "Hash": "b2d0b0a17142ed4858f252d88eb56223"
     },
     "ca": {
       "Package": "ca",
@@ -807,16 +771,17 @@
     },
     "callr": {
       "Package": "callr",
-      "Version": "3.7.6",
+      "Version": "3.8.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "R6",
+        "otel",
         "processx",
         "utils"
       ],
-      "Hash": "d7e13f49c19103ece9e58ad2d83a7354"
+      "Hash": "cb2799e0a02c2ac4d0395b0e29bb6799"
     },
     "car": {
       "Package": "car",
@@ -855,7 +820,7 @@
     },
     "cards": {
       "Package": "cards",
-      "Version": "0.7.1",
+      "Version": "0.8.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -868,11 +833,11 @@
         "tidyr",
         "tidyselect"
       ],
-      "Hash": "78b4b998c31ef49c1e75b96f5e498bf2"
+      "Hash": "0f49ff3fb56262a47ba4f582c4cecc1c"
     },
     "cardx": {
       "Package": "cardx",
-      "Version": "0.3.2",
+      "Version": "0.3.4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -885,7 +850,7 @@
         "rlang",
         "tidyr"
       ],
-      "Hash": "f5c603963977f502b06f4931d9a763ee"
+      "Hash": "6eed70361109b605cc66b3ba340e44a5"
     },
     "cellranger": {
       "Package": "cellranger",
@@ -941,18 +906,28 @@
       ],
       "Hash": "155015404e9e9b55339384dec942fc7d"
     },
-    "class": {
-      "Package": "class",
-      "Version": "7.3-23",
+    "chromote": {
+      "Package": "chromote",
+      "Version": "0.5.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
-        "MASS",
-        "R",
-        "stats",
-        "utils"
+        "R6",
+        "cli",
+        "curl",
+        "fastmap",
+        "jsonlite",
+        "later",
+        "magrittr",
+        "processx",
+        "promises",
+        "rlang",
+        "utils",
+        "websocket",
+        "withr",
+        "zip"
       ],
-      "Hash": "d0cb9cc838c3b43560bd958fc4317fdc"
+      "Hash": "645cd21d708d14c2732a34b2ccba87b8"
     },
     "classInt": {
       "Package": "classInt",
@@ -972,28 +947,28 @@
     },
     "cli": {
       "Package": "cli",
-      "Version": "3.6.5",
+      "Version": "3.6.6",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "16850760556401a2eeb27d39bd11c9cb"
+      "Hash": "a73d822b669d443ff8de6928f9c49850"
     },
     "clipr": {
       "Package": "clipr",
-      "Version": "0.8.0",
+      "Version": "0.8.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "utils"
       ],
-      "Hash": "3f038e5ac7f41d4ac41ce658c85e3042"
+      "Hash": "cc6e507cf89f11ffc44b32519e0198da"
     },
     "clubSandwich": {
       "Package": "clubSandwich",
-      "Version": "0.6.2",
+      "Version": "0.7.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1002,21 +977,7 @@
         "sandwich",
         "stats"
       ],
-      "Hash": "45c2e9af8484812eb3cb70c16fd84ae2"
-    },
-    "cluster": {
-      "Package": "cluster",
-      "Version": "2.1.8.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "grDevices",
-        "graphics",
-        "stats",
-        "utils"
-      ],
-      "Hash": "e16d49a008e1a22ee863fb9a51de9bde"
+      "Hash": "aa6ac2da8a6bb076549ea51c02cc13b2"
     },
     "cmprsk": {
       "Package": "cmprsk",
@@ -1029,19 +990,9 @@
       ],
       "Hash": "c733af3a77ab8bde9b6a632197342cb9"
     },
-    "codetools": {
-      "Package": "codetools",
-      "Version": "0.2-20",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
-      "Hash": "61e097f35917d342622f21cdc79c256e"
-    },
     "coin": {
       "Package": "coin",
-      "Version": "1.4-3",
+      "Version": "1.4-5",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1058,22 +1009,22 @@
         "survival",
         "utils"
       ],
-      "Hash": "4084b5070a40ad99dad581ed3b67bd55"
+      "Hash": "4bf75823ffa387ea2630231cb397fb8c"
     },
     "collapse": {
       "Package": "collapse",
-      "Version": "2.1.6",
+      "Version": "2.1.7",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "Rcpp"
       ],
-      "Hash": "158158a0aad21d43154cf68f72d31fdc"
+      "Hash": "9c35542dc0acb8ff66128047585a7fef"
     },
     "colorspace": {
       "Package": "colorspace",
-      "Version": "2.1-2",
+      "Version": "2.1-3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1083,18 +1034,18 @@
         "methods",
         "stats"
       ],
-      "Hash": "2c14b873da71cacec1284f3f6d112ddc"
+      "Hash": "acb51c45a64447d9deb5e4d5c9e0de9e"
     },
     "common": {
       "Package": "common",
-      "Version": "1.1.4",
+      "Version": "1.1.5",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "8358b227f4a0026a4fe08471339013d6"
+      "Hash": "20bb061342078956abce7bcb010d0f0c"
     },
     "commonmark": {
       "Package": "commonmark",
@@ -1178,13 +1129,13 @@
     },
     "cpp11": {
       "Package": "cpp11",
-      "Version": "0.5.3",
+      "Version": "0.5.5",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "af5958631ca49510aff96d0f5c0bbb76"
+      "Hash": "20ecb9105a3fb48a8390919abc3b7e90"
     },
     "crayon": {
       "Package": "crayon",
@@ -1223,28 +1174,28 @@
     },
     "curl": {
       "Package": "curl",
-      "Version": "7.0.0",
+      "Version": "7.1.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "aa27e963d3deccf4bade44d06b976977"
+      "Hash": "2e004ed19964915a8faf48a574439be9"
     },
     "data.table": {
       "Package": "data.table",
-      "Version": "1.18.2.1",
+      "Version": "1.18.4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "methods"
       ],
-      "Hash": "df99cd4333ce592df5173d6ad39b5c14"
+      "Hash": "da9ddede68a6f6e5d3098c0ab81b6e1f"
     },
     "datawizard": {
       "Package": "datawizard",
-      "Version": "1.3.0",
+      "Version": "1.3.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1253,11 +1204,11 @@
         "stats",
         "utils"
       ],
-      "Hash": "6acfecf3792005ee2e2e1eb7ede6c1c1"
+      "Hash": "82c29732e404f45c41314eab720e52d3"
     },
     "dbplyr": {
       "Package": "dbplyr",
-      "Version": "2.5.2",
+      "Version": "2.6.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1281,7 +1232,7 @@
         "vctrs",
         "withr"
       ],
-      "Hash": "751a4c05422caab7c7f74f10a94961fa"
+      "Hash": "ddbed6865865c509ea0b516faf83042b"
     },
     "dendextend": {
       "Package": "dendextend",
@@ -1335,7 +1286,7 @@
     },
     "diffobj": {
       "Package": "diffobj",
-      "Version": "0.3.6",
+      "Version": "0.3.8",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1346,7 +1297,7 @@
         "tools",
         "utils"
       ],
-      "Hash": "e036ce354ab60e705ac5f40bac87e8cb"
+      "Hash": "fc69a29e9a851af8d0d07b3d4ed1dea4"
     },
     "digest": {
       "Package": "digest",
@@ -1361,7 +1312,7 @@
     },
     "distributional": {
       "Package": "distributional",
-      "Version": "0.6.0",
+      "Version": "0.8.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1375,11 +1326,11 @@
         "utils",
         "vctrs"
       ],
-      "Hash": "e39534d5c70549298cbe7dc2f1fda65b"
+      "Hash": "72f50cd7f9ae374a323c832ab6c25171"
     },
     "doBy": {
       "Package": "doBy",
-      "Version": "4.7.1",
+      "Version": "4.7.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1394,18 +1345,17 @@
         "forecast",
         "ggplot2",
         "methods",
-        "microbenchmark",
         "modelr",
         "purrr",
         "rlang",
         "tibble",
         "tidyr"
       ],
-      "Hash": "5f2c39d5a7cac55afb304e3a70c77554"
+      "Hash": "da344b4511e1b22d30dc39e62e9c9bbc"
     },
     "dplyr": {
       "Package": "dplyr",
-      "Version": "1.2.0",
+      "Version": "1.2.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1424,7 +1374,7 @@
         "utils",
         "vctrs"
       ],
-      "Hash": "71a469a5d5f9fdbf7de6c0dbeece0e22"
+      "Hash": "d71f190466b9496cf8543c76641be5cf"
     },
     "dtplyr": {
       "Package": "dtplyr",
@@ -1475,7 +1425,7 @@
     },
     "emmeans": {
       "Package": "emmeans",
-      "Version": "2.0.1",
+      "Version": "2.0.4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1489,15 +1439,16 @@
         "stats",
         "utils"
       ],
-      "Hash": "a080e7cd7ab0cede46c10b6fd5aaad7e"
+      "Hash": "4b1a9deaadc921992795563ef658ca19"
     },
     "epiR": {
       "Package": "epiR",
-      "Version": "2.0.90",
+      "Version": "2.0.96",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "BiasedUrn",
+        "DFBA",
         "R",
         "flextable",
         "lubridate",
@@ -1509,18 +1460,18 @@
         "survival",
         "zoo"
       ],
-      "Hash": "8e7a32486485bcc4d6913936ad042421"
+      "Hash": "76bd40b89fdaab589b7cc050807aac94"
     },
     "estimability": {
       "Package": "estimability",
-      "Version": "1.5.1",
+      "Version": "2.0.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "stats"
       ],
-      "Hash": "21ec52af13afbcab1cb317567b639b0a"
+      "Hash": "0a032de8b3ae5b5695c8319112607bda"
     },
     "evaluate": {
       "Package": "evaluate",
@@ -1547,7 +1498,7 @@
     },
     "exactRankTests": {
       "Package": "exactRankTests",
-      "Version": "0.8-35",
+      "Version": "0.8-37",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1555,7 +1506,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "790c46974d99ff51442f4d134b2d70eb"
+      "Hash": "0aa957b0217c8f42e1b36d907a730c47"
     },
     "exactci": {
       "Package": "exactci",
@@ -1582,24 +1533,22 @@
     },
     "factoextra": {
       "Package": "factoextra",
-      "Version": "1.0.7",
+      "Version": "2.2.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "FactoMineR",
         "R",
-        "abind",
         "cluster",
         "dendextend",
         "ggplot2",
         "ggpubr",
         "ggrepel",
         "grid",
-        "reshape2",
-        "stats",
-        "tidyr"
+        "rlang",
+        "stats"
       ],
-      "Hash": "e95f1aed34b3f0a15a0c308175ee4c80"
+      "Hash": "d80190c5c2e2b6256a33f1f94dd3e408"
     },
     "farver": {
       "Package": "farver",
@@ -1627,7 +1576,7 @@
     },
     "flextable": {
       "Package": "flextable",
-      "Version": "0.9.11",
+      "Version": "0.10.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1647,11 +1596,11 @@
         "uuid",
         "xml2"
       ],
-      "Hash": "016c4b282f7dbb621fa30560924a4085"
+      "Hash": "4b9095bab25f9ff8387974c5ecd63a17"
     },
     "fmtr": {
       "Package": "fmtr",
-      "Version": "1.7.2",
+      "Version": "1.7.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1662,7 +1611,7 @@
         "stats",
         "tibble"
       ],
-      "Hash": "140920169f881d71e3464e72e6ef9c35"
+      "Hash": "6befcde47439097225914c969bd5ef63"
     },
     "fontBitstreamVera": {
       "Package": "fontBitstreamVera",
@@ -1739,7 +1688,7 @@
     },
     "forecast": {
       "Package": "forecast",
-      "Version": "9.0.1",
+      "Version": "9.0.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1761,20 +1710,7 @@
         "withr",
         "zoo"
       ],
-      "Hash": "0dc371e253fbaa8ce2257d584b11d4c2"
-    },
-    "foreign": {
-      "Package": "foreign",
-      "Version": "0.8-90",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "methods",
-        "stats",
-        "utils"
-      ],
-      "Hash": "f8bb52cf63a7ba97c87e47ede10976ad"
+      "Hash": "71233b4e8fb32f511e8a12649680d05a"
     },
     "formula.tools": {
       "Package": "formula.tools",
@@ -1791,44 +1727,43 @@
     },
     "fracdiff": {
       "Package": "fracdiff",
-      "Version": "1.5-3",
+      "Version": "1.5-4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "stats"
       ],
-      "Hash": "a74597c42c5343764548aee4930e1ee1"
+      "Hash": "92aa27e070368ad50727dfc3787f53e9"
     },
     "fs": {
       "Package": "fs",
-      "Version": "1.6.6",
+      "Version": "2.1.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "methods"
       ],
-      "Hash": "7eb1e342eee7e0a7449c49cdaa526d39"
+      "Hash": "09278623bca442bc53b0940ffa2f6d87"
     },
     "furrr": {
       "Package": "furrr",
-      "Version": "0.3.1",
+      "Version": "0.4.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "future",
         "globals",
-        "lifecycle",
         "purrr",
         "rlang",
         "vctrs"
       ],
-      "Hash": "da7a4c32196cb2262a41dd5a25d486ff"
+      "Hash": "fe9f6c435f0414d91239025eef7b524c"
     },
     "future": {
       "Package": "future",
-      "Version": "1.69.0",
+      "Version": "1.75.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1838,9 +1773,10 @@
         "listenv",
         "parallel",
         "parallelly",
+        "tools",
         "utils"
       ],
-      "Hash": "ddd903a23d4fd2fe030d509520119ad1"
+      "Hash": "4de585b60e8ae1881bd1e541363214c4"
     },
     "gargle": {
       "Package": "gargle",
@@ -1879,7 +1815,7 @@
     },
     "gdtools": {
       "Package": "gdtools",
-      "Version": "0.5.0",
+      "Version": "0.5.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1890,17 +1826,17 @@
         "systemfonts",
         "tools"
       ],
-      "Hash": "37212f50bcbb0d9f90bb86f56bc007bb"
+      "Hash": "bca589967c4b7360ced3c08c69a96787"
     },
     "gee": {
       "Package": "gee",
-      "Version": "4.13-29",
+      "Version": "4.13-30",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "stats"
       ],
-      "Hash": "6633962fa53cc9ff2c1aec45612ff9fc"
+      "Hash": "f774a7faa472ad6dbad1e21ad23a8af6"
     },
     "geepack": {
       "Package": "geepack",
@@ -1929,7 +1865,7 @@
     },
     "ggplot2": {
       "Package": "ggplot2",
-      "Version": "4.0.2",
+      "Version": "4.0.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1947,11 +1883,11 @@
         "vctrs",
         "withr"
       ],
-      "Hash": "24744d322a00a520db329287bf02ce42"
+      "Hash": "98520fe6b2745c466dca8e46aaa86242"
     },
     "ggpubr": {
       "Package": "ggpubr",
-      "Version": "0.6.2",
+      "Version": "1.0.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1976,27 +1912,28 @@
         "tidyr",
         "utils"
       ],
-      "Hash": "3dc2857459c3c1205d25f476b849e66e"
+      "Hash": "58fb9092542e81010ee0f37dde2c0bd3"
     },
     "ggrepel": {
       "Package": "ggrepel",
-      "Version": "0.9.6",
+      "Version": "0.9.8",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "Rcpp",
+        "S7",
         "ggplot2",
         "grid",
         "rlang",
         "scales",
         "withr"
       ],
-      "Hash": "3d4156850acc1161f2f24bc61c9217c1"
+      "Hash": "6e050646dfa53b2f0e4e4235bd671292"
     },
     "ggsci": {
       "Package": "ggsci",
-      "Version": "4.2.0",
+      "Version": "5.2.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2006,7 +1943,7 @@
         "rlang",
         "scales"
       ],
-      "Hash": "35ba608c15370846d5e964902ad634e5"
+      "Hash": "e2b372a76c19030bdbd7db0351d1bf2e"
     },
     "ggsignif": {
       "Package": "ggsignif",
@@ -2020,7 +1957,7 @@
     },
     "ggsurvfit": {
       "Package": "ggsurvfit",
-      "Version": "1.2.0",
+      "Version": "1.2.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2036,7 +1973,7 @@
         "survival",
         "tidyr"
       ],
-      "Hash": "e53139457d2bb40b77edb67919f8bbce"
+      "Hash": "2eb4c567dc4059fdd1a67efbb300b2f2"
     },
     "ggtext": {
       "Package": "ggtext",
@@ -2099,7 +2036,7 @@
     },
     "glmnet": {
       "Package": "glmnet",
-      "Version": "4.1-10",
+      "Version": "5.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2113,29 +2050,29 @@
         "survival",
         "utils"
       ],
-      "Hash": "158d36283dd26ca74066e6c09226a72f"
+      "Hash": "daf8b015885fc731b8c617d24d933395"
     },
     "globals": {
       "Package": "globals",
-      "Version": "0.19.0",
+      "Version": "0.19.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "codetools"
       ],
-      "Hash": "e246ec04a6e68961fbfd8d3f15c6218b"
+      "Hash": "7ccd5e4cffcdc6ab901626110b203584"
     },
     "glue": {
       "Package": "glue",
-      "Version": "1.8.0",
+      "Version": "1.8.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "methods"
       ],
-      "Hash": "5899f1eaa825580172bb56c08266f37c"
+      "Hash": "f8122473e9a49e00d0642f78235ca5e3"
     },
     "gmodels": {
       "Package": "gmodels",
@@ -2224,7 +2161,7 @@
     },
     "gridExtra": {
       "Package": "gridExtra",
-      "Version": "2.3",
+      "Version": "2.3.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2234,11 +2171,11 @@
         "gtable",
         "utils"
       ],
-      "Hash": "7d7f283939f563670a697165b2cf5560"
+      "Hash": "4e172eb9a8e2e01e0494ea230b73f068"
     },
     "gridtext": {
       "Package": "gridtext",
-      "Version": "0.1.5",
+      "Version": "0.1.6",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2254,11 +2191,11 @@
         "stringr",
         "xml2"
       ],
-      "Hash": "05e4f5fffb1eecfeaac9ea0b7f255fef"
+      "Hash": "44ba01d9fa1dda584a3f880c212dcd93"
     },
     "gsDesign": {
       "Package": "gsDesign",
-      "Version": "3.9.0",
+      "Version": "3.10.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2276,11 +2213,11 @@
         "tools",
         "xtable"
       ],
-      "Hash": "1219b1ca9e68786ee96232da7f82e9c3"
+      "Hash": "6e11a712fdb397f6b33a1cd87c786a33"
     },
     "gsDesign2": {
       "Package": "gsDesign2",
-      "Version": "1.1.8",
+      "Version": "1.2.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2301,7 +2238,7 @@
         "tidyr",
         "utils"
       ],
-      "Hash": "db2f31586da8a91a3bffc456c6e33e71"
+      "Hash": "454a23a2af7fba9f9b006730be478499"
     },
     "gt": {
       "Package": "gt",
@@ -2363,7 +2300,7 @@
     },
     "gtsummary": {
       "Package": "gtsummary",
-      "Version": "2.5.0",
+      "Version": "2.5.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2379,11 +2316,11 @@
         "tidyr",
         "vctrs"
       ],
-      "Hash": "ef592ba4c689a6867e9f571697fa2ecb"
+      "Hash": "55d23d7b05dbb99ec5653d7f68ef5ca9"
     },
     "hardhat": {
       "Package": "hardhat",
-      "Version": "1.4.2",
+      "Version": "1.4.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2395,7 +2332,7 @@
         "tibble",
         "vctrs"
       ],
-      "Hash": "3925b503926399e7f9ae563faf11da4d"
+      "Hash": "d7610d4cd0047f81634ebc1faecacbf1"
     },
     "haven": {
       "Package": "haven",
@@ -2430,14 +2367,14 @@
     },
     "highr": {
       "Package": "highr",
-      "Version": "0.11",
+      "Version": "0.12",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "xfun"
       ],
-      "Hash": "d65ba49117ca223614f71b60d85b8ab7"
+      "Hash": "2a2f862ade01a56dcbcd60944de11255"
     },
     "hms": {
       "Package": "hms",
@@ -2456,7 +2393,7 @@
     },
     "htmlTable": {
       "Package": "htmlTable",
-      "Version": "2.4.3",
+      "Version": "2.5.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2470,7 +2407,7 @@
         "rstudioapi",
         "stringr"
       ],
-      "Hash": "ca027d8771f2c039aed82f00a81e725b"
+      "Hash": "5cfe71c7cec41d4843ba54ac7c8b9355"
     },
     "htmltools": {
       "Package": "htmltools",
@@ -2529,6 +2466,29 @@
       ],
       "Hash": "99df65cfef20e525ed38c3d2577f7190"
     },
+    "igraph": {
+      "Package": "igraph",
+      "Version": "2.3.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "Matrix",
+        "R",
+        "cli",
+        "cpp11",
+        "grDevices",
+        "graphics",
+        "lifecycle",
+        "magrittr",
+        "methods",
+        "pkgconfig",
+        "rlang",
+        "stats",
+        "utils",
+        "vctrs"
+      ],
+      "Hash": "1ef1a63466353036c14f192a124d1549"
+    },
     "inline": {
       "Package": "inline",
       "Version": "0.3.21",
@@ -2541,7 +2501,7 @@
     },
     "insight": {
       "Package": "insight",
-      "Version": "1.4.6",
+      "Version": "1.5.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2550,7 +2510,20 @@
         "stats",
         "utils"
       ],
-      "Hash": "c3c6595dfc27f57a0031a6548076e0d8"
+      "Hash": "7b9afd9199b100e5deaa3f91d6faff2b"
+    },
+    "irlba": {
+      "Package": "irlba",
+      "Version": "2.3.7",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "Matrix",
+        "R",
+        "methods",
+        "stats"
+      ],
+      "Hash": "329cd64734cabb9e82d13503d5e6112c"
     },
     "isoband": {
       "Package": "isoband",
@@ -2668,18 +2641,6 @@
       ],
       "Hash": "3bcd11943da509341838da9399e18bce"
     },
-    "km.ci": {
-      "Package": "km.ci",
-      "Version": "0.5-6",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "stats",
-        "survival"
-      ],
-      "Hash": "41d857f78edf8f5db59608b6a42b6005"
-    },
     "knitr": {
       "Package": "knitr",
       "Version": "1.51",
@@ -2728,7 +2689,7 @@
     },
     "later": {
       "Package": "later",
-      "Version": "1.4.6",
+      "Version": "1.4.8",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2736,26 +2697,11 @@
         "Rcpp",
         "rlang"
       ],
-      "Hash": "a651844fe479e1cc9c2355f74a722ae6"
-    },
-    "lattice": {
-      "Package": "lattice",
-      "Version": "0.22-7",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "grDevices",
-        "graphics",
-        "grid",
-        "stats",
-        "utils"
-      ],
-      "Hash": "934f30aea6442867f57a610034ab06d3"
+      "Hash": "824c180e69b9be79ab96a985e233c470"
     },
     "lavaan": {
       "Package": "lavaan",
-      "Version": "0.6-21",
+      "Version": "0.7-2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2771,17 +2717,18 @@
         "stats4",
         "utils"
       ],
-      "Hash": "bbe0a613f6b8d6db76a37a1924d0c4f1"
+      "Hash": "c5a930ce6cf452dc272a2caefa614ed1"
     },
     "lazyeval": {
       "Package": "lazyeval",
-      "Version": "0.2.2",
+      "Version": "0.2.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
-        "R"
+        "R",
+        "rlang"
       ],
-      "Hash": "d908914ae53b04d4c0c0fd72ecc35370"
+      "Hash": "2757e46c2633dd5854f62615df70d0d7"
     },
     "leaps": {
       "Package": "leaps",
@@ -2792,7 +2739,7 @@
     },
     "libcoin": {
       "Package": "libcoin",
-      "Version": "1.0-11",
+      "Version": "1.0-13",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2800,7 +2747,7 @@
         "mvtnorm",
         "stats"
       ],
-      "Hash": "93f4a49f798031107629653b0fbbd0c4"
+      "Hash": "68d41be2b6dddf01880400e0c4ad1fa3"
     },
     "lifecycle": {
       "Package": "lifecycle",
@@ -2816,17 +2763,17 @@
     },
     "listenv": {
       "Package": "listenv",
-      "Version": "0.10.0",
+      "Version": "1.0.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "6debfba65f9df176bbb98bc63f934272"
+      "Hash": "c5a4adae4290385ff5819e02ff9b9931"
     },
     "litedown": {
       "Package": "litedown",
-      "Version": "0.9",
+      "Version": "0.10",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2835,11 +2782,11 @@
         "utils",
         "xfun"
       ],
-      "Hash": "6b9435273e6506fbafa5909adf4abb88"
+      "Hash": "0bb78ad1932aa147c433f16183382219"
     },
     "lme4": {
       "Package": "lme4",
-      "Version": "1.1-38",
+      "Version": "2.0-6",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2859,16 +2806,15 @@
         "nloptr",
         "parallel",
         "reformulas",
-        "rlang",
         "splines",
         "stats",
         "utils"
       ],
-      "Hash": "0a0abf28da4a31382cf6d523f2e1e3d1"
+      "Hash": "dbedab779d23065e0f4905b79429fa68"
     },
     "lmom": {
       "Package": "lmom",
-      "Version": "3.2",
+      "Version": "3.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2876,7 +2822,7 @@
         "graphics",
         "stats"
       ],
-      "Hash": "a75d2dd42af9b4cb291815889cdcff77"
+      "Hash": "ac4b8fed655d152553e8208b78078cda"
     },
     "lmtest": {
       "Package": "lmtest",
@@ -2907,7 +2853,7 @@
     },
     "loo": {
       "Package": "loo",
-      "Version": "2.9.0",
+      "Version": "2.10.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2918,7 +2864,7 @@
         "posterior",
         "stats"
       ],
-      "Hash": "553d13a5e2b45cfd7ca2d782a7054f31"
+      "Hash": "557142a63f951e40db1af9f907365cfc"
     },
     "lubridate": {
       "Package": "lubridate",
@@ -2935,13 +2881,13 @@
     },
     "magrittr": {
       "Package": "magrittr",
-      "Version": "2.0.4",
+      "Version": "2.0.5",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "8b3b213aa0c54a0dec254288ccb545d1"
+      "Hash": "665e77ab6e5f37a7913226d40b324e37"
     },
     "markdown": {
       "Package": "markdown",
@@ -3007,7 +2953,7 @@
     },
     "merDeriv": {
       "Package": "merDeriv",
-      "Version": "0.2-5",
+      "Version": "0.2-6",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -3022,24 +2968,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "12196168eeebfe7e6c73328812a680f4"
-    },
-    "mgcv": {
-      "Package": "mgcv",
-      "Version": "1.9-3",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "Matrix",
-        "R",
-        "graphics",
-        "methods",
-        "nlme",
-        "splines",
-        "stats",
-        "utils"
-      ],
-      "Hash": "51fcbccd59569cdad6da6b8e49cdf4f2"
+      "Hash": "b958fe1bdcc871b3b35ac861f8e44e7e"
     },
     "mice": {
       "Package": "mice",
@@ -3139,7 +3068,7 @@
     },
     "mmrm": {
       "Package": "mmrm",
-      "Version": "0.3.17",
+      "Version": "0.3.18",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -3162,7 +3091,7 @@
         "tibble",
         "utils"
       ],
-      "Hash": "f16234e9c97b54463bb4c62314182046"
+      "Hash": "9e03ced755deb0f4983018780a73099e"
     },
     "mnormt": {
       "Package": "mnormt",
@@ -3211,9 +3140,20 @@
       "Repository": "CRAN",
       "Hash": "bb94fd8ee5f7f127eae2bddbff26864d"
     },
+    "muhaz": {
+      "Package": "muhaz",
+      "Version": "1.2.6.5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "survival"
+      ],
+      "Hash": "5925fd639ecaa05db6e9777bc895e2e5"
+    },
     "multcomp": {
       "Package": "multcomp",
-      "Version": "1.4-29",
+      "Version": "1.4-31",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -3225,17 +3165,17 @@
         "stats",
         "survival"
       ],
-      "Hash": "3350139bac9264546e523634ff6aa74b"
+      "Hash": "e6cf35bb9128e705a848363da2ca4bc3"
     },
     "multcompView": {
       "Package": "multcompView",
-      "Version": "0.1-11",
+      "Version": "0.1-12",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "grid"
       ],
-      "Hash": "e043f633d898be14de143d5a32457a78"
+      "Hash": "9b4782acb7684558e63c0255331b9aed"
     },
     "multgee": {
       "Package": "multgee",
@@ -3267,28 +3207,15 @@
     },
     "mvtnorm": {
       "Package": "mvtnorm",
-      "Version": "1.3-3",
+      "Version": "1.4-2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
-        "stats"
-      ],
-      "Hash": "c7241e6be9d6df551a2e539a50f5c875"
-    },
-    "nlme": {
-      "Package": "nlme",
-      "Version": "3.1-168",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "graphics",
-        "lattice",
         "stats",
         "utils"
       ],
-      "Hash": "b1d2ea08d5d392831fbc32c872362b06"
+      "Hash": "f12b9432ec251666c49e7d01f1aff3c7"
     },
     "nloptr": {
       "Package": "nloptr",
@@ -3297,21 +3224,9 @@
       "Repository": "CRAN",
       "Hash": "dd6975473dd4c9b96e9be93b796b9c1a"
     },
-    "nnet": {
-      "Package": "nnet",
-      "Version": "7.3-20",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "stats",
-        "utils"
-      ],
-      "Hash": "c955edf99ff24a32e96bd0a22645af60"
-    },
     "nonnest2": {
       "Package": "nonnest2",
-      "Version": "0.5-8",
+      "Version": "0.5-9",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -3322,7 +3237,7 @@
         "mvtnorm",
         "sandwich"
       ],
-      "Hash": "f76473d3210524e30c0ec2e5b91f8455"
+      "Hash": "9df8b8ecad5a549b79a28652f488b57f"
     },
     "nph": {
       "Package": "nph",
@@ -3338,8 +3253,8 @@
         "mvtnorm",
         "stats",
         "survival"
-        ],
-        "Hash": "aef516378ec2181493aa2bdeb08f94d7"
+      ],
+      "Hash": "aef516378ec2181493aa2bdeb08f94d7"
     },
     "nphRCT": {
       "Package": "nphRCT",
@@ -3378,7 +3293,7 @@
     },
     "officer": {
       "Package": "officer",
-      "Version": "0.7.3",
+      "Version": "0.7.6",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -3396,17 +3311,17 @@
         "xml2",
         "zip"
       ],
-      "Hash": "6c1b10689d4e3a49a50a093c4bd263ef"
+      "Hash": "8ecbb62f412a5939760ea7eb565acc77"
     },
     "openssl": {
       "Package": "openssl",
-      "Version": "2.3.4",
+      "Version": "2.4.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "askpass"
       ],
-      "Hash": "d5811dade9cd3a34a9038a45f1a59bae"
+      "Hash": "6994d1c3ea954f29de6aeca5da95c99d"
     },
     "operator.tools": {
       "Package": "operator.tools",
@@ -3437,7 +3352,7 @@
     },
     "ordinal": {
       "Package": "ordinal",
-      "Version": "2025.12-29",
+      "Version": "2026.7-26",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -3450,7 +3365,7 @@
         "stats",
         "ucminf"
       ],
-      "Hash": "e4f565f2e23677b4245ee511e2b291c9"
+      "Hash": "41d4647ceb1cce9aab3937fe25348a39"
     },
     "otel": {
       "Package": "otel",
@@ -3464,13 +3379,10 @@
     },
     "pan": {
       "Package": "pan",
-      "Version": "1.9",
+      "Version": "2.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
-      "Hash": "aefe2753a8e7277e0fdd6d1d08d1692e"
+      "Hash": "9abc4f798150b318a13afcc277e9d636"
     },
     "pander": {
       "Package": "pander",
@@ -3492,7 +3404,7 @@
     },
     "parallelly": {
       "Package": "parallelly",
-      "Version": "1.46.1",
+      "Version": "1.48.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -3500,11 +3412,11 @@
         "tools",
         "utils"
       ],
-      "Hash": "f4d2d1926bcb9a9384193bd7fea39fe3"
+      "Hash": "a21defc75d66882933d80b7ae824a7b1"
     },
     "parameters": {
       "Package": "parameters",
-      "Version": "0.28.3",
+      "Version": "0.29.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -3517,11 +3429,11 @@
         "stats",
         "utils"
       ],
-      "Hash": "5c812a68308c47fa9cafbfebccc3e356"
+      "Hash": "b574f87f7b4ba68770acb837cfd3fe2c"
     },
     "parsnip": {
       "Package": "parsnip",
-      "Version": "1.4.1",
+      "Version": "1.6.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -3544,10 +3456,9 @@
         "tibble",
         "tidyr",
         "utils",
-        "vctrs",
-        "withr"
+        "vctrs"
       ],
-      "Hash": "01b65f5a5d1397b31f62defa71cce5b2"
+      "Hash": "2097696035afde4836f54ea4a0bb524c"
     },
     "patchwork": {
       "Package": "patchwork",
@@ -3647,7 +3558,7 @@
     },
     "pkgload": {
       "Package": "pkgload",
-      "Version": "1.5.0",
+      "Version": "1.5.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -3664,7 +3575,7 @@
         "rprojroot",
         "utils"
       ],
-      "Hash": "91a99cbfcb01c854584e7d1b69035c2c"
+      "Hash": "912acb56e1e3362766b63278d8b60a61"
     },
     "plm": {
       "Package": "plm",
@@ -3690,7 +3601,7 @@
     },
     "plotly": {
       "Package": "plotly",
-      "Version": "4.12.0",
+      "Version": "4.12.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -3706,7 +3617,6 @@
         "htmlwidgets",
         "httr",
         "jsonlite",
-        "lazyeval",
         "magrittr",
         "promises",
         "purrr",
@@ -3718,28 +3628,17 @@
         "vctrs",
         "viridisLite"
       ],
-      "Hash": "282f8b208bc767c67a370b47bff6ada7"
-    },
-    "plyr": {
-      "Package": "plyr",
-      "Version": "1.8.9",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "Rcpp"
-      ],
-      "Hash": "6b8177fd19982f0020743fadbfdbd933"
+      "Hash": "3609e47f0d9713dfd7f68bd6e731e27b"
     },
     "png": {
       "Package": "png",
-      "Version": "0.1-8",
+      "Version": "0.1-9",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "bd54ba8a0a5faded999a7aab6e46b374"
+      "Hash": "961c433971606243a724eb19b1075e60"
     },
     "polspline": {
       "Package": "polspline",
@@ -3765,7 +3664,7 @@
     },
     "posterior": {
       "Package": "posterior",
-      "Version": "1.6.1",
+      "Version": "1.7.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -3783,7 +3682,7 @@
         "tibble",
         "vctrs"
       ],
-      "Hash": "6ce9d5bf852882c96029dfc35b46da2b"
+      "Hash": "5c78a3f8f08513ca28a3df5211f016db"
     },
     "praise": {
       "Package": "praise",
@@ -3804,7 +3703,7 @@
     },
     "processx": {
       "Package": "processx",
-      "Version": "3.8.6",
+      "Version": "3.9.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -3813,24 +3712,26 @@
         "ps",
         "utils"
       ],
-      "Hash": "720161b280b0a35f4d1490ead2fe81d0"
+      "Hash": "188d6caf38e81bf15b5e918726a6fd3d"
     },
     "procs": {
       "Package": "procs",
-      "Version": "1.0.7",
+      "Version": "1.0.9",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "common",
         "fmtr",
+        "graphics",
         "reporter",
         "sasLM",
         "stats",
         "tibble",
-        "utils"
+        "utils",
+        "withr"
       ],
-      "Hash": "7b941743d6101b315e73c6652c3246db"
+      "Hash": "001f28a451da3ab559c0f1849e4d95a2"
     },
     "progress": {
       "Package": "progress",
@@ -3877,18 +3778,18 @@
     },
     "ps": {
       "Package": "ps",
-      "Version": "1.9.1",
+      "Version": "1.9.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "093688087b0bacce6ba2f661f36328e2"
+      "Hash": "83e7e486c434e7acc71766dfc20adf2b"
     },
     "purrr": {
       "Package": "purrr",
-      "Version": "1.2.1",
+      "Version": "1.2.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -3899,7 +3800,7 @@
         "rlang",
         "vctrs"
       ],
-      "Hash": "0154ac5b9ef4df1a7be3a54602e781cf"
+      "Hash": "0a35605539b085a4828ec55ad973fe60"
     },
     "pwr": {
       "Package": "pwr",
@@ -3949,7 +3850,7 @@
     },
     "r2rtf": {
       "Package": "r2rtf",
-      "Version": "1.3.0",
+      "Version": "1.3.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -3957,18 +3858,18 @@
         "grDevices",
         "tools"
       ],
-      "Hash": "036ba1ef84d42329c59a07958b290027"
+      "Hash": "6646b92ae9296ff667622eac1231bbbe"
     },
     "ragg": {
       "Package": "ragg",
-      "Version": "1.5.0",
+      "Version": "1.5.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "systemfonts",
         "textshaping"
       ],
-      "Hash": "cdb40b21711a8870f305b24226698f9f"
+      "Hash": "c06b460d55dd27458977e417e8ff02c7"
     },
     "rappdirs": {
       "Package": "rappdirs",
@@ -3986,14 +3887,14 @@
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
-      "RemoteRepo": "ratesci",
       "RemoteUsername": "petelaud",
-      "RemotePkgRef": "petelaud/ratesci",
+      "RemoteRepo": "ratesci",
+      "RemoteRef": "e1cd177c0f1fac61e8837d798f87a97c3c56a161",
       "RemoteSha": "e1cd177c0f1fac61e8837d798f87a97c3c56a161",
       "Requirements": [
         "R"
       ],
-      "Hash": "ba42cacf19fe2f8c3c08faa17d7c93cc"
+      "Hash": "b59285780b3f393c521abd8a63812121"
     },
     "rbibutils": {
       "Package": "rbibutils",
@@ -4009,7 +3910,7 @@
     },
     "rbmi": {
       "Package": "rbmi",
-      "Version": "1.6.0",
+      "Version": "1.6.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -4019,13 +3920,14 @@
         "assertthat",
         "fs",
         "jinjar",
+        "lifecycle",
         "methods",
         "mmrm",
         "pkgload",
         "stringr",
         "tools"
       ],
-      "Hash": "5ed5f819dbf63b81fcaa0593f554ea3f"
+      "Hash": "7375406ade6cdd7c429716cc4a0f7c4f"
     },
     "reactR": {
       "Package": "reactR",
@@ -4054,7 +3956,7 @@
     },
     "readr": {
       "Package": "readr",
-      "Version": "2.1.6",
+      "Version": "2.2.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -4064,6 +3966,7 @@
         "clipr",
         "cpp11",
         "crayon",
+        "glue",
         "hms",
         "lifecycle",
         "methods",
@@ -4071,13 +3974,14 @@
         "tibble",
         "tzdb",
         "utils",
-        "vroom"
+        "vroom",
+        "withr"
       ],
-      "Hash": "141ebcec1bf55707751c7956a34d93db"
+      "Hash": "4425ad9e28b8e3351184ca2739995b87"
     },
     "readxl": {
       "Package": "readxl",
-      "Version": "1.4.5",
+      "Version": "1.5.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -4088,7 +3992,7 @@
         "tibble",
         "utils"
       ],
-      "Hash": "18948de59f05d38a44d3e5065a76b4b6"
+      "Hash": "db51be8ae666e3d16195395b9058a91a"
     },
     "reformulas": {
       "Package": "reformulas",
@@ -4144,7 +4048,7 @@
     },
     "reporter": {
       "Package": "reporter",
-      "Version": "1.4.6",
+      "Version": "1.4.8",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -4160,7 +4064,7 @@
         "withr",
         "zip"
       ],
-      "Hash": "a033d4c973ec27ec29b15270b414a2ef"
+      "Hash": "492792a9e5c8277d503e84e8219f5b1c"
     },
     "reprex": {
       "Package": "reprex",
@@ -4184,22 +4088,9 @@
       ],
       "Hash": "97b1d5361a24d9fb588db7afe3e5bcbf"
     },
-    "reshape2": {
-      "Package": "reshape2",
-      "Version": "1.4.5",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "Rcpp",
-        "plyr",
-        "stringr"
-      ],
-      "Hash": "2677962d949a7a879537a2364d56be84"
-    },
     "reticulate": {
       "Package": "reticulate",
-      "Version": "1.45.0",
+      "Version": "1.46.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -4217,40 +4108,18 @@
         "utils",
         "withr"
       ],
-      "Hash": "fdbcdf00a192b3a2acd86cadd1c1ff91"
-    },
-    "rgl": {
-      "Package": "rgl",
-      "Version": "1.3.34",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "R6",
-        "base64enc",
-        "grDevices",
-        "graphics",
-        "htmltools",
-        "htmlwidgets",
-        "jsonlite",
-        "knitr",
-        "magrittr",
-        "mime",
-        "stats",
-        "utils"
-      ],
-      "Hash": "e819ef706f8aeb01b3b803433281fe4e"
+      "Hash": "4a05d547e002c567ad087b0ea1d52774"
     },
     "rlang": {
       "Package": "rlang",
-      "Version": "1.1.7",
+      "Version": "1.3.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "34c0d101f4613098abc538b82e0d86c5"
+      "Hash": "8d05afdb0b0dd5ef01b306db289fe21f"
     },
     "rlemon": {
       "Package": "rlemon",
@@ -4265,7 +4134,7 @@
     },
     "rmarkdown": {
       "Package": "rmarkdown",
-      "Version": "2.30",
+      "Version": "2.31",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -4284,7 +4153,7 @@
         "xfun",
         "yaml"
       ],
-      "Hash": "efe19db0fde0fff13cea7eec6f695021"
+      "Hash": "f34039d57d861d2869cbf9be813ed08e"
     },
     "rms": {
       "Package": "rms",
@@ -4348,19 +4217,6 @@
       ],
       "Hash": "3aea2099d950c2b75b8680273647bae0"
     },
-    "rpart": {
-      "Package": "rpart",
-      "Version": "4.1.24",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "grDevices",
-        "graphics",
-        "stats"
-      ],
-      "Hash": "ad31b457482eda7a12e51c5d8e7b0be4"
-    },
     "rprojroot": {
       "Package": "rprojroot",
       "Version": "2.1.1",
@@ -4421,7 +4277,7 @@
     },
     "rstatix": {
       "Package": "rstatix",
-      "Version": "0.7.3",
+      "Version": "1.1.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -4440,14 +4296,14 @@
         "tidyselect",
         "utils"
       ],
-      "Hash": "e8b46cf278914385c7cb2bf4bce2f88a"
+      "Hash": "6bb8ed79199a00221c7a3beb6daccc21"
     },
     "rstudioapi": {
       "Package": "rstudioapi",
-      "Version": "0.18.0",
+      "Version": "0.19.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "d6e1ecf8e39b6d53c8acde372b2f92d1"
+      "Hash": "db86914207e4e0f112b60ebbc3e1793c"
     },
     "rvest": {
       "Package": "rvest",
@@ -4470,7 +4326,7 @@
     },
     "s2": {
       "Package": "s2",
-      "Version": "1.1.9",
+      "Version": "1.1.11",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -4478,7 +4334,7 @@
         "Rcpp",
         "wk"
       ],
-      "Hash": "4e664a5d610d58f27ec196e96cdb7f6f"
+      "Hash": "54b09824b3ac78eb4fa44f76c0616131"
     },
     "samplesize": {
       "Package": "samplesize",
@@ -4489,7 +4345,7 @@
     },
     "sandwich": {
       "Package": "sandwich",
-      "Version": "3.1-1",
+      "Version": "3.1-3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -4498,19 +4354,24 @@
         "utils",
         "zoo"
       ],
-      "Hash": "072bb2d27425f2a58fe71fe1080676ce"
+      "Hash": "b371412dbbf43cf39d0302556a0b7c39"
     },
     "sasLM": {
       "Package": "sasLM",
-      "Version": "0.10.7",
+      "Version": "1.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
+        "grDevices",
+        "graphics",
         "methods",
-        "mvtnorm"
+        "mvtnorm",
+        "stats",
+        "tools",
+        "utils"
       ],
-      "Hash": "2f8e8e88b3267f0d61319e77876eaf90"
+      "Hash": "98153af4af3af99fa0c2fc9a74f4e84e"
     },
     "sass": {
       "Package": "sass",
@@ -4547,7 +4408,7 @@
     },
     "scatterplot3d": {
       "Package": "scatterplot3d",
-      "Version": "0.3-44",
+      "Version": "0.3-45",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -4556,20 +4417,18 @@
         "graphics",
         "stats"
       ],
-      "Hash": "10ee4b91ec812690bd55d9bf51edccee"
+      "Hash": "e5723914ce450822d08213e2c0e92ca8"
     },
     "selectr": {
       "Package": "selectr",
-      "Version": "0.5-1",
+      "Version": "0.6-0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
-        "R6",
-        "methods",
-        "stringr"
+        "R6"
       ],
-      "Hash": "fb6f4aacfcc16539458c66b698339e69"
+      "Hash": "c538f20abf5a9a4ab8fac8f1ee3f50e8"
     },
     "sensitivity2x2xk": {
       "Package": "sensitivity2x2xk",
@@ -4614,20 +4473,20 @@
     },
     "sessioninfo": {
       "Package": "sessioninfo",
-      "Version": "1.2.2",
+      "Version": "1.2.4",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "cli",
         "tools",
         "utils"
       ],
-      "Hash": "3f9796a8d0a0e8c6eb49a4b029359d1f"
+      "Hash": "0cffa1e2f8c8a67e000fc75db09892f1"
     },
     "sf": {
       "Package": "sf",
-      "Version": "1.0-24",
+      "Version": "1.1-2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -4638,7 +4497,6 @@
         "grDevices",
         "graphics",
         "grid",
-        "magrittr",
         "methods",
         "s2",
         "stats",
@@ -4646,7 +4504,7 @@
         "units",
         "utils"
       ],
-      "Hash": "7a4756aedf70812aa33fba3d29529424"
+      "Hash": "02483c8ee4115581472646cd5d5984d9"
     },
     "shape": {
       "Package": "shape",
@@ -4660,6 +4518,29 @@
         "stats"
       ],
       "Hash": "5c47e84dc0a3ca761ae1d307889e796d"
+    },
+    "showtext": {
+      "Package": "showtext",
+      "Version": "0.9-8",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "grDevices",
+        "showtextdb",
+        "sysfonts"
+      ],
+      "Hash": "599c73082d4a9f00fde3c7bc7eb669ff"
+    },
+    "showtextdb": {
+      "Package": "showtextdb",
+      "Version": "3.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "sysfonts",
+        "utils"
+      ],
+      "Hash": "c12e756cf947e58b0f2c2a520521a5a8"
     },
     "slider": {
       "Package": "slider",
@@ -4719,12 +4600,12 @@
       "Requirements": [
         "R",
         "mvtnorm"
-        ],
-        "Hash": "8dd22e4fb2dfce04d0d4927771e61aba"
+      ],
+      "Hash": "8dd22e4fb2dfce04d0d4927771e61aba"
     },
     "stringi": {
       "Package": "stringi",
-      "Version": "1.8.7",
+      "Version": "1.8.9",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -4733,7 +4614,7 @@
         "tools",
         "utils"
       ],
-      "Hash": "2b56088e23bdd58f89aebf43a0913457"
+      "Hash": "67f6c2a9e67d08e1e419ff89ad135444"
     },
     "stringr": {
       "Package": "stringr",
@@ -4752,32 +4633,19 @@
       ],
       "Hash": "d47392652eedc68bf916657347ff2526"
     },
-    "survMisc": {
-      "Package": "survMisc",
-      "Version": "0.5.6",
+    "survRM2": {
+      "Package": "survRM2",
+      "Version": "1.0-4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
-        "KMsurv",
-        "data.table",
-        "ggplot2",
-        "grDevices",
-        "graphics",
-        "grid",
-        "gridExtra",
-        "km.ci",
-        "knitr",
-        "stats",
-        "survival",
-        "utils",
-        "xtable",
-        "zoo"
+        "survival"
       ],
-      "Hash": "2367feed5d6f99ee1e380da3eac55ab6"
+      "Hash": "6af75caf3bfa6dd6b0a6ef0fed599478"
     },
     "survey": {
       "Package": "survey",
-      "Version": "4.4-8",
+      "Version": "4.5",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -4796,27 +4664,11 @@
         "stats",
         "survival"
       ],
-      "Hash": "b30e7e82e4bebedc3e509976c7dd7403"
-    },
-    "survival": {
-      "Package": "survival",
-      "Version": "3.8-3",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "Matrix",
-        "R",
-        "graphics",
-        "methods",
-        "splines",
-        "stats",
-        "utils"
-      ],
-      "Hash": "fe42836742a4f065b3f3f5de81fccab9"
+      "Hash": "e8eab1ebe57968ce5e4f92c36348a518"
     },
     "survminer": {
       "Package": "survminer",
-      "Version": "0.5.1",
+      "Version": "0.5.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -4834,12 +4686,11 @@
         "rlang",
         "scales",
         "stats",
-        "survMisc",
         "survival",
         "tibble",
         "tidyr"
       ],
-      "Hash": "d0e3855987f93df5f194b1240aaa30a5"
+      "Hash": "0b5b30ad970581d2bcbe106b24bef5ef"
     },
     "sys": {
       "Package": "sys",
@@ -4848,9 +4699,16 @@
       "Repository": "CRAN",
       "Hash": "de342ebfebdbf40477d0758d05426646"
     },
+    "sysfonts": {
+      "Package": "sysfonts",
+      "Version": "0.8.9",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "7dfca1e9c5c278300b5ca6a1772072f7"
+    },
     "systemfonts": {
       "Package": "systemfonts",
-      "Version": "1.3.1",
+      "Version": "1.3.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -4863,7 +4721,7 @@
         "tools",
         "utils"
       ],
-      "Hash": "4fae513a3bb1a155943d1e9d1ae467ec"
+      "Hash": "1f930828d6590af5da47b3ab4fe161e6"
     },
     "tensorA": {
       "Package": "tensorA",
@@ -4906,7 +4764,7 @@
     },
     "textshaping": {
       "Package": "textshaping",
-      "Version": "1.0.4",
+      "Version": "1.0.5",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -4918,7 +4776,7 @@
         "systemfonts",
         "utils"
       ],
-      "Hash": "477d70e23914730aa7f5c5fd351f4721"
+      "Hash": "addb750a886a2ac415dea6f8068867de"
     },
     "tibble": {
       "Package": "tibble",
@@ -4941,7 +4799,7 @@
     },
     "tidycmprsk": {
       "Package": "tidycmprsk",
-      "Version": "1.1.1",
+      "Version": "1.1.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -4960,7 +4818,7 @@
         "tibble",
         "tidyr"
       ],
-      "Hash": "0003cdeb29c3ce3bb94fb05a13bc34b2"
+      "Hash": "95ea265245b8866cb59dce89eeefb854"
     },
     "tidyr": {
       "Package": "tidyr",
@@ -5068,13 +4926,13 @@
     },
     "tinytex": {
       "Package": "tinytex",
-      "Version": "0.58",
+      "Version": "0.60",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "xfun"
       ],
-      "Hash": "03af3ad04817f3019de8ee5c73dab807"
+      "Hash": "263651b52279eaa7835e44aa32f9b754"
     },
     "tzdb": {
       "Package": "tzdb",
@@ -5089,24 +4947,24 @@
     },
     "ucminf": {
       "Package": "ucminf",
-      "Version": "1.2.2",
+      "Version": "1.2.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "e0750b911c01c3e5aaab143a86e9e478"
+      "Hash": "1a25002d0e84de7ccd0807c7d63ce9fc"
     },
     "units": {
       "Package": "units",
-      "Version": "1.0-0",
+      "Version": "1.0-1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "Rcpp"
       ],
-      "Hash": "3797c73fd3bde8b1601a4e1bf53557ac"
+      "Hash": "14743a941151a12449e8af67497c7b96"
     },
     "urca": {
       "Package": "urca",
@@ -5144,7 +5002,7 @@
     },
     "vcd": {
       "Package": "vcd",
-      "Version": "1.4-13",
+      "Version": "1.4-14",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -5157,11 +5015,11 @@
         "stats",
         "utils"
       ],
-      "Hash": "c371981692e15016fd45aa5cf8f9b42c"
+      "Hash": "48b5337cfd2e425ec77c56c60c69c373"
     },
     "vcdExtra": {
       "Package": "vcdExtra",
-      "Version": "0.9.1",
+      "Version": "0.9.7",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -5170,21 +5028,27 @@
         "ca",
         "colorspace",
         "dplyr",
+        "forcats",
         "gnm",
         "grDevices",
         "grid",
         "gt",
-        "rgl",
+        "htmlwidgets",
+        "igraph",
+        "knitr",
+        "methods",
+        "rlang",
         "scales",
         "stats",
         "utils",
-        "vcd"
+        "vcd",
+        "webshot2"
       ],
-      "Hash": "4ac959f853d8588bc2b841eeace108ae"
+      "Hash": "24d69862b7c6b584dd37bc14857fc2e8"
     },
     "vctrs": {
       "Package": "vctrs",
-      "Version": "0.7.1",
+      "Version": "0.7.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -5194,7 +5058,7 @@
         "lifecycle",
         "rlang"
       ],
-      "Hash": "c64e64d93489bb62bb8747bbb9e06c09"
+      "Hash": "2dcde2d30d3ad67bf1d3a37177457b87"
     },
     "viridis": {
       "Package": "viridis",
@@ -5221,7 +5085,7 @@
     },
     "vroom": {
       "Package": "vroom",
-      "Version": "1.7.0",
+      "Version": "1.7.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -5243,7 +5107,7 @@
         "vctrs",
         "withr"
       ],
-      "Hash": "255cb6f090718455ff89cbc28cb5eea7"
+      "Hash": "1e9494eda38f3418f71474363293da2a"
     },
     "waldo": {
       "Package": "waldo",
@@ -5270,9 +5134,37 @@
       ],
       "Hash": "8010fb39b9d16c928d924c2f310c0f6c"
     },
+    "webshot2": {
+      "Package": "webshot2",
+      "Version": "0.1.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "callr",
+        "chromote",
+        "later",
+        "magrittr",
+        "promises"
+      ],
+      "Hash": "eebb1681cf21e47cf55e882f19c75648"
+    },
+    "websocket": {
+      "Package": "websocket",
+      "Version": "1.4.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "AsioHeaders",
+        "R6",
+        "cpp11",
+        "later"
+      ],
+      "Hash": "1c674e92da114a65ce2b5a1ab59997ed"
+    },
     "withr": {
       "Package": "withr",
-      "Version": "3.0.2",
+      "Version": "3.0.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -5280,7 +5172,7 @@
         "grDevices",
         "graphics"
       ],
-      "Hash": "cc2d62c76458d425210d1eb1478b30b4"
+      "Hash": "d979712ec72df779bc2d30bcc5d0d541"
     },
     "wk": {
       "Package": "wk",
@@ -5294,7 +5186,7 @@
     },
     "xfun": {
       "Package": "xfun",
-      "Version": "0.56",
+      "Version": "0.60",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -5303,11 +5195,11 @@
         "stats",
         "tools"
       ],
-      "Hash": "f1f18d352a39c6252932da4faa029cdd"
+      "Hash": "8304c2894061f6ae062996f09dd1528e"
     },
     "xgboost": {
       "Package": "xgboost",
-      "Version": "3.2.0.1",
+      "Version": "3.2.1.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -5317,11 +5209,11 @@
         "jsonlite",
         "methods"
       ],
-      "Hash": "6b1cd6c890fb985627c9d7529318ca83"
+      "Hash": "fd89e5cf669b6291404b3e3b38737c6f"
     },
     "xml2": {
       "Package": "xml2",
-      "Version": "1.5.2",
+      "Version": "1.6.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -5330,19 +5222,20 @@
         "methods",
         "rlang"
       ],
-      "Hash": "d8e98d08a4a4d03f5052acc6e6204b99"
+      "Hash": "568fe669c645b2007e4e8fcf5cde40e7"
     },
     "xtable": {
       "Package": "xtable",
-      "Version": "1.8-4",
+      "Version": "1.8-8",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
+        "methods",
         "stats",
         "utils"
       ],
-      "Hash": "b8acdf8af494d9ec19ccb2481a9b11c2"
+      "Hash": "93b19c064862d315a828c7170d806453"
     },
     "yaml": {
       "Package": "yaml",
@@ -5353,14 +5246,17 @@
     },
     "zip": {
       "Package": "zip",
-      "Version": "2.3.3",
+      "Version": "3.0.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "6ebe4b1dc74c3e50e74e316323629583"
+      "Requirements": [
+        "cli"
+      ],
+      "Hash": "5807bea03035bfdd7535c1d3eb258cb0"
     },
     "zoo": {
       "Package": "zoo",
-      "Version": "1.8-15",
+      "Version": "1.9-0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -5371,7 +5267,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "3f85ec88dadbaa3301917cea59727329"
+      "Hash": "246123b6990acc8dfc4969d3e7225e2d"
     }
   }
 }

--- a/renv/settings.json
+++ b/renv/settings.json
@@ -1,7 +1,23 @@
 {
   "bioconductor.version": null,
   "external.libraries": [],
-  "ignored.packages": [],
+  "ignored.packages": [
+    "boot",
+    "class",
+    "cluster",
+    "codetools",
+    "foreign",
+    "KernSmooth",
+    "lattice",
+    "MASS",
+    "Matrix",
+    "mgcv",
+    "nlme",
+    "nnet",
+    "rpart",
+    "spatial",
+    "survival"
+  ],
   "package.dependency.fields": [
     "Imports",
     "Depends",


### PR DESCRIPTION
# What's broken

Every CI run since about 24 July has failed at the "Set up renv" step — every
branch, including pushes straight to `main`. So this isn't something #598, #608
or #609 did. It broke on its own and it's been blocking everything since.

# Why

Two things went wrong together.

**renv.lock was asking for package versions that no longer exist.** It pointed
at the Posit Package Manager "latest" address, which only ever offers the
newest version of each package. Our lockfile pinned 154 packages to older
versions than that. When renv can't get a ready-built copy, it falls back to
building the package from source code — and a lot of those old versions won't
build on a modern Linux machine.

**But we never noticed, because of the cache.** GitHub kept a saved copy of the
whole package library, built back when those versions *were* current, and every
run just reused it. Then GitHub swapped `ubuntu-latest` to a newer Ubuntu image
in mid-July. The cache is tied to the OS version, so it was thrown away, and
suddenly every run had to install all 374 packages for real. That's when the
150-odd source builds actually had to happen, and they failed.

This is also why Abi's `ubuntu-22.04` change in #609 didn't help — changing the
Ubuntu version just gives you a *different* empty cache, so you still face the
same failing builds. Nothing wrong with the idea, it just couldn't work alone.

And it's the same reason `renv::restore()` has been failing on Macs locally.

# What this PR does

**Points renv at a fixed date instead of "latest."** The package manager keeps
dated archives, so `cran/2026-08-14` gives us a snapshot where every version we
want is available pre-built for Linux, macOS and Windows. I then re-took the
snapshot so all our recorded versions match that date. CI now downloads
ready-made packages and compiles nothing.

**Stops pinning the packages that come bundled with R.** Things like `mgcv`,
`Matrix`, `survival` and `lattice` are installed as part of R itself, so their
version depends on which R you have, not on CRAN. Pinning them can never work —
this is exactly what was failing on Macs, where the lockfile wanted mgcv 1.9-3
but R 4.5.3 ships 1.9-4. They're now excluded, and everyone just uses whatever
their R came with. The pre-render script already copes with this.

**Adds survRM2 (and muhaz, which it needs)** so #598 can finally go in.

**Removes survMisc.** CRAN archived it back in March, `survminer` no longer
needs it, and our pages only mention it in the text — nothing actually calls it.
A few packages that were only there to support it (`km.ci`, `KMsurv`, `plyr`,
`reshape2`, `rgl`) drop out too.

**Pins the Ubuntu version in both workflows.** Not because 24.04 is special, but
so that the next time GitHub moves `ubuntu-latest`, it doesn't silently bin our
cache and catch us out again.

**Adds notes to the contributor guide** about the two things above that bite
people.

**Adding a new package from now on** gives you the version that was current on
14 August. If you need something newer, we move the date forward, which is a
change worth doing on its own rather than tacked onto a content PR.

# Two things to keep an eye on afterwards

**Someone needs to move the snapshot date forward every so often. Now that
we're pinned to 14 August 2026, we stay on those package versions until someone
deliberately bumps the date. That's the point - it's what makes restores
reproducible! But it does mean the gap between us and current CRAN grows
quietly in the background.**

I'd suggest treating it as a routine maintenance job: move the date forward
every six months or so, ideally at the same time as an R version bump, and
always as its own PR rather than bolted onto a content change. This is more or
less what Christina used to do for us. Worth either putting a recurring
reminder somewhere or making it a standing agenda item, because it won't happen
if it depends on somebody remembering!

# Worth Noting

**Snapshots taken on a laptop pick up your local setup.** `renv::snapshot()`
also rewrites `requirements.txt` and the Python version from whatever Python
environment you happen to have active. While putting this PR together it cut
`requirements.txt` from 124 packages down to 1, because my local Python
environment is empty. I caught it and put it back, and it's the same thing that
affected #608.

I've added a note to the contributor guide for now, but doing snapshots in CI
instead would remove the trap altogether. Happy to set that up separately if
people think it's worth it?? 